### PR TITLE
Cake Wallet adaptations to wallet2_api

### DIFF
--- a/src/wallet/api/CMakeLists.txt
+++ b/src/wallet/api/CMakeLists.txt
@@ -37,6 +37,7 @@ set(wallet_api_sources
   transaction_history.cpp
   pending_transaction.cpp
   utils.cpp
+  assets.cpp
   address_book.cpp
   subaddress.cpp
   subaddress_account.cpp
@@ -67,6 +68,7 @@ target_link_libraries(wallet_api
   PUBLIC
     wallet
     common
+    offshore
     cryptonote_core
     mnemonics
     ${LMDB_LIBRARY}

--- a/src/wallet/api/assets.cpp
+++ b/src/wallet/api/assets.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2018-2021, Haven Protocol
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+
+#include <vector>
+#include <string>
+#include <offshore/asset_types.h>
+
+using namespace std;
+
+namespace Monero {
+    
+namespace Assets {
+
+std::vector<std::string> list()
+{ 
+  return offshore::ASSET_TYPES; 
+}
+
+}
+
+} // namespace
+
+

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -162,6 +162,7 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
     return m_status == Status_Ok;
 }
 
+//TO-DO
 uint64_t PendingTransactionImpl::amount() const
 {
     uint64_t result = 0;
@@ -171,6 +172,11 @@ uint64_t PendingTransactionImpl::amount() const
         }
     }
     return result;
+}
+
+string PendingTransactionImpl::assetType() const
+{
+    return m_asset_type;
 }
 
 uint64_t PendingTransactionImpl::dust() const

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -47,6 +47,7 @@ public:
     std::string errorString() const override;
     bool commit(const std::string &filename = "", bool overwrite = false) override;
     uint64_t amount() const override;
+    std::string assetType () const override;
     uint64_t dust() const override;
     uint64_t fee() const override;
     std::vector<std::string> txid() const override;
@@ -65,9 +66,11 @@ private:
 
     int  m_status;
     std::string m_errorString;
+    std::string m_asset_type;
     std::vector<tools::wallet2::pending_tx> m_pending_tx;
     std::unordered_set<crypto::public_key> m_signers;
     std::vector<std::string> m_tx_device_aux;
+    //TO-DO
     std::vector<crypto::key_image> m_key_images;
 };
 

--- a/src/wallet/api/subaddress_account.cpp
+++ b/src/wallet/api/subaddress_account.cpp
@@ -32,6 +32,13 @@
 #include "wallet/wallet2.h"
 #include "common_defines.h"
 
+
+#include "cryptonote_basic/cryptonote_format_utils.h"
+#include "cryptonote_basic/cryptonote_basic_impl.h"
+#include <boost/format.hpp>
+
+
+
 #include <vector>
 
 namespace Monero {
@@ -64,8 +71,8 @@ void SubaddressAccountImpl::refresh()
       i,
       m_wallet->m_wallet->get_subaddress_as_str({i,0}),
       m_wallet->m_wallet->get_subaddress_label({i,0}),
-      cryptonote::print_money(m_wallet->m_wallet->balance(i, false)),
-      cryptonote::print_money(m_wallet->m_wallet->unlocked_balance(i, false))
+      m_wallet->m_wallet->balance(i, false),
+      m_wallet->m_wallet->unlocked_balance(i, false)
     ));
   }
 }

--- a/src/wallet/api/transaction_info.cpp
+++ b/src/wallet/api/transaction_info.cpp
@@ -134,6 +134,11 @@ string TransactionInfoImpl::paymentId() const
     return m_paymentid;
 }
 
+string TransactionInfoImpl::assetType() const
+{
+    return m_assettype;
+}
+
 const std::vector<TransactionInfo::Transfer> &TransactionInfoImpl::transfers() const
 {
     return m_transfers;

--- a/src/wallet/api/transaction_info.h
+++ b/src/wallet/api/transaction_info.h
@@ -59,6 +59,7 @@ public:
     virtual std::string hash() const override;
     virtual std::time_t timestamp() const override;
     virtual std::string paymentId() const override;
+    virtual std::string assetType() const override;
     virtual const std::vector<Transfer> &transfers() const override;
     virtual uint64_t confirmations() const override;
     virtual uint64_t unlockTime() const override;
@@ -78,6 +79,7 @@ private:
     std::string m_hash;
     std::time_t m_timestamp;
     std::string m_paymentid;
+    std::string m_assettype;
     std::vector<Transfer> m_transfers;
     uint64_t    m_confirmations;
     uint64_t    m_unlock_time;

--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -97,6 +97,7 @@ bool UnsignedTransactionImpl::sign(const std::string &signedFileName)
 }
 
 //----------------------------------------------------------------------------------------------------
+//TO-DO
 bool UnsignedTransactionImpl::checkLoadedTx(const std::function<size_t()> get_num_txes, const std::function<const tools::wallet2::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message)
 {
   // gather info to ask the user

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -110,8 +110,14 @@ public:
     void setTrustedDaemon(bool arg) override;
     bool trustedDaemon() const override;
     bool setProxy(const std::string &address) override;
-    uint64_t balance(uint32_t accountIndex = 0) const override;
-    uint64_t unlockedBalance(uint32_t accountIndex = 0) const override;
+    std::map<uint32_t, std::map<std::string, uint64_t>> balance(uint32_t accountIndex = 0) const override;
+    std::map<uint32_t, std::map<std::string, uint64_t>> unlockedBalance(uint32_t accountIndex = 0) const override;
+    uint64_t balance(std::string asset_type, uint32_t accountIndex) const override;
+    uint64_t unlockedBalance(std::string asset_type, uint32_t accountIndex) const override;
+
+    std::map<std::string, uint64_t> balanceAll() const override;
+    std::map<std::string, uint64_t> unlockedBalanceAll() const override;
+    std::map<std::string, uint64_t> oracleRates() const override;
     uint64_t blockChainHeight() const override;
     uint64_t approximateBlockChainHeight() const override;
     uint64_t estimateBlockChainHeight() const override;
@@ -153,12 +159,12 @@ public:
     PendingTransaction*  restoreMultisigTransaction(const std::string& signData) override;
 
     PendingTransaction * createTransactionMultDest(const std::vector<std::string> &dst_addr, const std::string &payment_id,
-                                        optional<std::vector<uint64_t>> amount, uint32_t mixin_count,
+                                        optional<std::vector<uint64_t>> amount, const std::string &str_source, const std::string &str_dest, uint32_t mixin_count,
                                         PendingTransaction::Priority priority = PendingTransaction::Priority_Low,
                                         uint32_t subaddr_account = 0,
                                         std::set<uint32_t> subaddr_indices = {}) override;
     PendingTransaction * createTransaction(const std::string &dst_addr, const std::string &payment_id,
-                                        optional<uint64_t> amount, uint32_t mixin_count,
+                                        optional<uint64_t> amount, const std::string &str_source, const std::string &str_dest, uint32_t mixin_count,
                                         PendingTransaction::Priority priority = PendingTransaction::Priority_Low,
                                         uint32_t subaddr_account = 0,
                                         std::set<uint32_t> subaddr_indices = {}) override;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -39,6 +39,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <cstdint>
+#include <map>
 
 //  Public interface for libwallet library
 namespace Monero {
@@ -48,7 +49,10 @@ enum NetworkType : uint8_t {
     TESTNET,
     STAGENET
 };
+    namespace Assets {
 
+        std::vector<std::string> list();
+    }
     namespace Utils {
         bool isAddressLocal(const std::string &hostaddr);
         void onStartup();
@@ -92,6 +96,7 @@ struct PendingTransaction
     // commit transaction or save to file if filename is provided.
     virtual bool commit(const std::string &filename = "", bool overwrite = false) = 0;
     virtual uint64_t amount() const = 0;
+    virtual std::string assetType() const = 0;
     virtual uint64_t dust() const = 0;
     virtual uint64_t fee() const = 0;
     virtual std::vector<std::string> txid() const = 0;
@@ -197,6 +202,7 @@ struct TransactionInfo
     virtual std::string hash() const = 0;
     virtual std::time_t timestamp() const = 0;
     virtual std::string paymentId() const = 0;
+    virtual std::string assetType() const = 0;
     //! only applicable for output transactions
     virtual const std::vector<Transfer> & transfers() const = 0;
 };
@@ -288,9 +294,10 @@ struct Subaddress
     virtual void refresh(uint32_t accountIndex) = 0;
 };
 
+//TO-DO
 struct SubaddressAccountRow {
 public:
-    SubaddressAccountRow(std::size_t _rowId, const std::string &_address, const std::string &_label, const std::string &_balance, const std::string &_unlockedBalance):
+    SubaddressAccountRow(std::size_t _rowId, const std::string &_address, const std::string &_label, const std::map<uint32_t, std::map<std::string, uint64_t>> &_balance, const std::map<uint32_t, std::map<std::string, uint64_t>> &_unlockedBalance):
         m_rowId(_rowId),
         m_address(_address),
         m_label(_label),
@@ -301,14 +308,14 @@ private:
     std::size_t m_rowId;
     std::string m_address;
     std::string m_label;
-    std::string m_balance;
-    std::string m_unlockedBalance;
+    std::map<uint32_t, std::map<std::string, uint64_t>> m_balance;
+    std::map<uint32_t, std::map<std::string, uint64_t>> m_unlockedBalance;
 public:
     std::string extra;
     std::string getAddress() const {return m_address;}
     std::string getLabel() const {return m_label;}
-    std::string getBalance() const {return m_balance;}
-    std::string getUnlockedBalance() const {return m_unlockedBalance;}
+    std::map<uint32_t, std::map<std::string, uint64_t>> getBalance() const {return m_balance;}
+    std::map<uint32_t, std::map<std::string, uint64_t>> getUnlockedBalance() const {return m_unlockedBalance;}
     std::size_t getRowId() const {return m_rowId;}
 };
 
@@ -352,14 +359,14 @@ struct WalletListener
      * @param txId       - transaction id
      * @param amount     - amount
      */
-    virtual void moneySpent(const std::string &txId, uint64_t amount) = 0;
+    virtual void moneySpent(const std::string &txId, uint64_t amount, std::string asset_type) = 0;
 
     /**
      * @brief moneyReceived - called when money received
      * @param txId          - transaction id
      * @param amount        - amount
      */
-    virtual void moneyReceived(const std::string &txId, uint64_t amount) = 0;
+    virtual void moneyReceived(const std::string &txId, uint64_t amount, std::string asset_type) = 0;
 
    /**
     * @brief unconfirmedMoneyReceived - called when payment arrived in tx pool
@@ -606,20 +613,13 @@ struct Wallet
     virtual void setTrustedDaemon(bool arg) = 0;
     virtual bool trustedDaemon() const = 0;
     virtual bool setProxy(const std::string &address) = 0;
-    virtual uint64_t balance(uint32_t accountIndex = 0) const = 0;
-    uint64_t balanceAll() const {
-        uint64_t result = 0;
-        for (uint32_t i = 0; i < numSubaddressAccounts(); ++i)
-            result += balance(i);
-        return result;
-    }
-    virtual uint64_t unlockedBalance(uint32_t accountIndex = 0) const = 0;
-    uint64_t unlockedBalanceAll() const {
-        uint64_t result = 0;
-        for (uint32_t i = 0; i < numSubaddressAccounts(); ++i)
-            result += unlockedBalance(i);
-        return result;
-    }
+    virtual std::map<uint32_t, std::map<std::string, uint64_t>> balance(uint32_t accountIndex = 0) const = 0;
+    virtual uint64_t balance(std::string asset_type, uint32_t accountIndex) const = 0;
+    virtual std::map<std::string, uint64_t> balanceAll() const = 0;
+    virtual std::map<uint32_t, std::map<std::string, uint64_t>> unlockedBalance(uint32_t accountIndex = 0) const = 0;
+    virtual uint64_t unlockedBalance(std::string asset_type, uint32_t accountIndex) const = 0;
+    virtual std::map<std::string, uint64_t> unlockedBalanceAll() const = 0;
+    virtual std::map<std::string, uint64_t> oracleRates() const = 0;
 
    /**
     * @brief watchOnly - checks if wallet is watch only
@@ -840,7 +840,7 @@ struct Wallet
      */
 
     virtual PendingTransaction * createTransactionMultDest(const std::vector<std::string> &dst_addr, const std::string &payment_id,
-                                                   optional<std::vector<uint64_t>> amount, uint32_t mixin_count,
+                                                   optional<std::vector<uint64_t>> amount, const std::string &str_source, const std::string &str_dest, uint32_t mixin_count,
                                                    PendingTransaction::Priority = PendingTransaction::Priority_Low,
                                                    uint32_t subaddr_account = 0,
                                                    std::set<uint32_t> subaddr_indices = {}) = 0;
@@ -859,7 +859,7 @@ struct Wallet
      */
 
     virtual PendingTransaction * createTransaction(const std::string &dst_addr, const std::string &payment_id,
-                                                   optional<uint64_t> amount, uint32_t mixin_count,
+                                                   optional<uint64_t> amount, const std::string &str_source, const std::string &str_dest, uint32_t mixin_count,
                                                    PendingTransaction::Priority = PendingTransaction::Priority_Low,
                                                    uint32_t subaddr_account = 0,
                                                    std::set<uint32_t> subaddr_indices = {}) = 0;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1062,10 +1062,15 @@ private:
     bool key_on_device() const { return get_device_type() != hw::device::device_type::SOFTWARE; }
     hw::device::device_type get_device_type() const { return m_key_device_type; }
     bool reconnect_device();
-
+    // all locked & unlocked balances of all subaddress accounts
+    std::map<std::string, uint64_t> balance_all(bool strict);
+    std::map<std::string, uint64_t> unlocked_balance_all(bool strict, std::map<std::string, uint64_t> *blocks_to_unlock = NULL, std::map<std::string, uint64_t> *time_to_unlock = NULL); 
     // locked & unlocked balance of given or current subaddress account
     uint64_t balance(uint32_t subaddr_index_major, const std::string& asset, bool strict) const;
     uint64_t unlocked_balance(uint32_t subaddr_index_major, const std::string& asset, bool strict, uint64_t *blocks_to_unlock = NULL, uint64_t *time_to_unlock = NULL);
+    // locked & unlocked balance of given or current subaddress account
+    std::map<uint32_t, std::map<std::string, uint64_t>> balance(uint32_t subaddr_index_major, bool strict);
+    std::map<uint32_t, std::map<std::string, uint64_t>> unlocked_balance(uint32_t subaddr_index_major, bool strict, std::map<std::string, uint64_t> *blocks_to_unlock = NULL, std::map<std::string, uint64_t> *time_to_unlock = NULL);
     // locked & unlocked balance per subaddress of given or current subaddress account
     std::map<uint32_t, uint64_t> balance_per_subaddress(uint32_t subaddr_index_major, const std::string& asset, bool strict) const;
     std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlocked_balance_per_subaddress(uint32_t subaddr_index_major, const std::string& asset, bool strict);


### PR DESCRIPTION
This pool request makes it possible to compile wallet2_api for Android, necessary for the integration with Cake Wallet.
It combines a Monero rebase of wallet2_api and a switch to the new Oracle spot rates.
Tests were done with this version and an Android version of Cake Wallet (latest version), and refresh and transfers seem to work. With some changes on Cake side, it is also possible to get the correct USD values using the spot Oracle rates.

Changes to wallet2.cpp were kept to a minimum.

Some things are still not perfect and will have to be fixed on Cake side (cannot be done by Haven):
- Change logic for converting to USD amounts based on the new Oracle rates
- Conversions are only showing the "outgoing" part, due to the fact that Cake uses the transaction hash as an ID of a payment, and a Map to store them
- Adding libcryptonote_format_utils_basic.a to the linking process


