### PR TITLE
fix floating point arithmetics differences causing difficulty drift

### DIFF
--- a/src/cryptonote_basic/difficulty.cpp
+++ b/src/cryptonote_basic/difficulty.cpp
@@ -300,11 +300,11 @@ namespace cryptonote {
 
 		// To get an average solvetime to within +/- ~0.1%, use an adjustment factor.
     // adjust=0.99 for 90 < N < 130
-		const double adjust = 0.998;
+		const long double adjust = 0.998;
 		// The divisor k normalizes LWMA.
-		const double k = N * (N + 1) / 2;
+		const long double k = N * (N + 1) / 2;
 
-		double LWMA(0), sum_inverse_D(0), harmonic_mean_D(0), nextDifficulty(0);
+		long double LWMA(0), sum_inverse_D(0), harmonic_mean_D(0), nextDifficulty(0);
 		int64_t solveTime(0);
 		uint64_t difficulty(0), next_difficulty(0);
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -256,6 +256,12 @@
 #define HF_VERSION_YIELD                        23
 #define HF_VERSION_CONVERSION_FEES_NOT_BURNT    23
 
+// Haven v4.1 definitions
+#define HF_VERSION_SLIPPAGE_V2                  24
+#define HF_VERSION_BURN                         24
+#define HF_VERSION_CONVERSION_FEES_NOT_BURNT_FINAL    24
+
+
 #define STAGENET_VERSION                        0x0e
 #define TESTNET_VERSION                         0x1b
 
@@ -263,6 +269,9 @@
 
 #define BURNT_CONVERSION_FEES_MINT_AMOUNT       ((uint64_t)2580000000000000000ull)
 #define BURNT_CONVERSION_FEES_MINT_HEIGHT       ((uint64_t)1656720)
+
+#define BURNT_CONVERSION_FEES_MINT_AMOUNT_FINAL       ((uint64_t)511812000000000000ull)
+#define BURNT_CONVERSION_FEES_MINT_HEIGHT_FINAL       ((uint64_t)1692002)
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 #define CRYPTONOTE_SCALING_2021_FEE_ROUNDING_PLACES 2

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -139,6 +139,7 @@
 #define BLOCKS_SYNCHRONIZING_MAX_COUNT                  2048   //must be a power of 2, greater than 128, equal to SEEDHASH_EPOCH_BLOCKS
 
 #define CRYPTONOTE_MEMPOOL_TX_LIVETIME                    86400  //seconds, one day
+#define CRYPTONOTE_MEMPOOL_TX_CONVERSION_LIVETIME         3600   //seconds, one hour
 #define CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME     604800 //seconds, one week
 
 

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1564,9 +1564,11 @@ namespace cryptonote
     std::list<std::pair<crypto::hash, uint64_t>> remove;
     m_blockchain.for_all_txpool_txes([this, &remove](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref*) {
       uint64_t tx_age = time(nullptr) - meta.receive_time;
+      bool has_conv_fee = (meta.offshore_fee > 0);
 
       if((tx_age > CRYPTONOTE_MEMPOOL_TX_LIVETIME && !meta.kept_by_block) ||
-         (tx_age > CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME && meta.kept_by_block) )
+         (tx_age > CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME && meta.kept_by_block) || 
+         (has_conv_fee && tx_age > CRYPTONOTE_MEMPOOL_TX_CONVERSION_LIVETIME && !meta.kept_by_block)) //Remove conversions faster, as their pricing record is outdated
       {
         LOG_PRINT_L1("Tx " << txid << " removed from tx pool due to outdated, age: " << tx_age );
         auto sorted_it = find_tx_in_sorted_container(txid);

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -499,12 +499,20 @@ namespace cryptonote
         return false;
       }
     } else {
-      // make sure there is no burnt/mint set for transfers, since these numbers will affect circulating supply.
-      if (tx.amount_burnt || tx.amount_minted) {
+      // make sure there is no burnt/mint set for transfers, unless it is a burn, since these numbers will affect circulating supply.
+
+      if ((tx.amount_burnt && hf_version<HF_VERSION_BURN)|| tx.amount_minted) {
         LOG_ERROR("error: Invalid Tx found. Amount burnt/mint > 0 for a transfer tx.");
         tvc.m_verifivation_failed = true;
         return false;
       }
+      if (hf_version >= HF_VERSION_BURN && tx.amount_minted) {
+        LOG_ERROR("error: Invalid Tx found. Amount mint > 0 for a transfer tx.");
+        tvc.m_verifivation_failed = true;
+        return false;
+      }
+
+
       // make sure no pr height set
       if (tx.pricing_record_height) {
         LOG_ERROR("error: Invalid Tx found. Tx pricing_record_height > 0 for a transfer tx.");

--- a/src/hardforks/hardforks.cpp
+++ b/src/hardforks/hardforks.cpp
@@ -49,7 +49,8 @@ const hardfork_t mainnet_hard_forks[] = {
   { 20, 1272875, 0, 1671618321 }, // Fork time is on or around 9th January 2023 at 10:00 GMT. Fork time finalised on 2022-12-21.
   { 21, 1439500, 0, 1690797000 }, // Fork time is on or around 29th August 2023 at 10:00 GMT. Fork time finalised on 2023-07-31.
   { 22, 1439544, 0, 1693999500 }, // Fork time is on or around 29th August 2023 at 12:05 GMT. Fork time finalised on 2023-09-06.
-  { 23, 1656000, 0, 1719672007 }  // Fork time is on or around 8th July 2024 at 09:00 GMT. Fork time finalised on 2024-06-29.
+  { 23, 1656000, 0, 1719672007 },  // Fork time is on or around 8th July 2024 at 09:00 GMT. Fork time finalised on 2024-06-29.
+  { 24, 1691182, 0, 1724716500 }  // Fork time is on or around 26th August 2024 at 23:55 GMT.
 };
 const size_t num_mainnet_hard_forks = sizeof(mainnet_hard_forks) / sizeof(mainnet_hard_forks[0]);
 const uint64_t mainnet_hard_fork_version_1_till = 1009826;
@@ -72,7 +73,8 @@ const hardfork_t testnet_hard_forks[] = {
   { 20, 100, 0, 1657094479 },
   { 21, 300, 0, 1680518049 },
   { 22, 400, 0, 1693999500 },
-  { 23, 450, 0, 1714641723 }
+  { 23, 450, 0, 1714641723 },
+  { 24, 500, 0, 1724716500 }
 };
 const size_t num_testnet_hard_forks = sizeof(testnet_hard_forks) / sizeof(testnet_hard_forks[0]);
 const uint64_t testnet_hard_fork_version_1_till = 624633;

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -1700,7 +1700,23 @@ namespace rct {
             CHECK_AND_ASSERT_MES(amount_collateral, false, "0 collateral requirement something went wrong! rejecting tx..");
         }
       }
+
+      if (strSource == strDest) {
+        CHECK_AND_ASSERT_MES(pr.empty(), false, "Pricing record found for a transfer! rejecting tx..");
+        CHECK_AND_ASSERT_MES(amount_collateral==0, false, "Collateral found for a transfer! rejecting tx..");
+        CHECK_AND_ASSERT_MES(amount_slippage==0, false, "Slippage found for a transfer! rejecting tx..");
+        if (version < HF_VERSION_BURN) {
+          CHECK_AND_ASSERT_MES(amount_burnt==0, false, "amount_burnt found for a transfer tx! rejecting tx.. ");
+          }
+      }
       
+      uint64_t amount_supply_burnt = 0;
+
+      if ((tx_type == tt::TRANSFER || tx_type == tt::OFFSHORE_TRANSFER || tx_type == tt::XASSET_TRANSFER) && version >= HF_VERSION_BURN && amount_burnt>0){
+        amount_supply_burnt = amount_burnt;
+      }
+      
+
       // OUTPUTS SUMMED FOR EACH COLOUR
       key zerokey = rct::identity();
       // Zi is intentionally set to a different value to zerokey, so that if a bug is introduced in the later logic, any comparison with zerokey will fail
@@ -1776,6 +1792,8 @@ namespace rct {
       key txnFeeKey = scalarmultH(d2h(rv.txnFee));
       // Calculate offshore conversion fee (also always in C colour)
       key txnOffshoreFeeKey = scalarmultH(d2h(rv.txnOffshoreFee));
+      // Calculate the supply burn (also always in C colour)
+      key amount_supply_burntKey = scalarmultH(d2h(amount_supply_burnt));
 
       // Sum the consumed outputs in their respective asset types (sumColIns = inputs in D)
       key sumPseudoOuts = zerokey;
@@ -1803,6 +1821,9 @@ namespace rct {
       // Subtract the sum of converted output commitments from the sum of consumed output commitments in D colour (if any are present)
       // (Note: there are only consumed output commitments in D colour if the transaction is an onshore and requires collateral)
       subKeys(sumD, sumColIns, sumOutpks_D);
+
+      //Remove burnt supply
+      subKeys(sumC, sumC, amount_supply_burntKey);
 
       if (version >= HF_VERSION_CONVERSION_FEES_IN_XHV) {
         // NEAC: Convert the fees for conversions to XHV


### PR DESCRIPTION
There is a difference in the precision of difficulty calculation between Linux x86_64 and Windows / Linux ARM8. It seems to relate to floating point arithmetic deviations, most likely coming from the additional -m64 flag (rounding to 53 bits) passed in linux.mk in the make depend configuration. Changing the type to long double seems to fix the issue and produce consistent results between Linux x86_64 and other Windows / Linux ARM8.

Additionally, add a 1 hour time limit of conversions remaining the transaction pool, as a temporary measure to help the current stuck transactions problem.