### PR TITLE
Haven 4.0.3 - fix difficulty drift and removal of stuck conversions from the pool after 1 hour

### DIFF
--- a/src/cryptonote_basic/difficulty.cpp
+++ b/src/cryptonote_basic/difficulty.cpp
@@ -300,11 +300,11 @@ namespace cryptonote {
 
 		// To get an average solvetime to within +/- ~0.1%, use an adjustment factor.
     // adjust=0.99 for 90 < N < 130
-		const double adjust = 0.998;
+		const long double adjust = 0.998;
 		// The divisor k normalizes LWMA.
-		const double k = N * (N + 1) / 2;
+		const long double k = N * (N + 1) / 2;
 
-		double LWMA(0), sum_inverse_D(0), harmonic_mean_D(0), nextDifficulty(0);
+		long double LWMA(0), sum_inverse_D(0), harmonic_mean_D(0), nextDifficulty(0);
 		int64_t solveTime(0);
 		uint64_t difficulty(0), next_difficulty(0);
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -139,6 +139,7 @@
 #define BLOCKS_SYNCHRONIZING_MAX_COUNT                  2048   //must be a power of 2, greater than 128, equal to SEEDHASH_EPOCH_BLOCKS
 
 #define CRYPTONOTE_MEMPOOL_TX_LIVETIME                    86400  //seconds, one day
+#define CRYPTONOTE_MEMPOOL_TX_CONVERSION_LIVETIME         3600   //seconds, one hour
 #define CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME     604800 //seconds, one week
 
 

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1564,9 +1564,11 @@ namespace cryptonote
     std::list<std::pair<crypto::hash, uint64_t>> remove;
     m_blockchain.for_all_txpool_txes([this, &remove](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref*) {
       uint64_t tx_age = time(nullptr) - meta.receive_time;
+      bool has_conv_fee = (meta.offshore_fee > 0);
 
       if((tx_age > CRYPTONOTE_MEMPOOL_TX_LIVETIME && !meta.kept_by_block) ||
-         (tx_age > CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME && meta.kept_by_block) )
+         (tx_age > CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME && meta.kept_by_block) || 
+         (has_conv_fee && tx_age > CRYPTONOTE_MEMPOOL_TX_CONVERSION_LIVETIME && !meta.kept_by_block)) //Remove conversions faster, as their pricing record is outdated
       {
         LOG_PRINT_L1("Tx " << txid << " removed from tx pool due to outdated, age: " << tx_age );
         auto sorted_it = find_tx_in_sorted_container(txid);


### PR DESCRIPTION
There is a difference in the precision of difficulty calculation between Linux x86_64 and Windows / Linux ARM8. It seems to relate to floating point arithmetic deviations, most likely coming from the additional -m64 flag (rounding to 53 bits) passed in linux.mk in the make depend configuration. Changing the type to long double seems to fix the issue and produce consistent results between Linux x86_64 and other Windows / Linux ARM8.

Additionally, add a 1 hour time limit of conversions remaining the transaction pool, as a temporary measure to help the current stuck transactions problem.
