### PR TITLE
Haven 4.1

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1107,7 +1107,8 @@ uint64_t BlockchainLMDB::add_transaction_data(const crypto::hash& blk_hash, cons
 
   bool is_mint_and_burn_tx = (strSource != strDest);
   bool is_burn_tx = (strSource == strDest) && tx.amount_burnt > 0;
-  // NEAC : check for presence of offshore TX or burn tx to see if we need to update circulating supply information
+  // NEAC : check for presence of offshore TX to see if we need to update circulating supply information
+  // Tay8NWWFKpz9JT4NXU0w: Also burn transactions affect the supply
   if ((tx.version >= OFFSHORE_TRANSACTION_VERSION) && (is_mint_and_burn_tx || is_burn_tx)) {  
     // Offshore TX - update our records
     circ_supply cs;

--- a/src/cryptonote_basic/difficulty.cpp
+++ b/src/cryptonote_basic/difficulty.cpp
@@ -300,11 +300,11 @@ namespace cryptonote {
 
 		// To get an average solvetime to within +/- ~0.1%, use an adjustment factor.
     // adjust=0.99 for 90 < N < 130
-		const double adjust = 0.998;
+		const long double adjust = 0.998;
 		// The divisor k normalizes LWMA.
-		const double k = N * (N + 1) / 2;
+		const long double k = N * (N + 1) / 2;
 
-		double LWMA(0), sum_inverse_D(0), harmonic_mean_D(0), nextDifficulty(0);
+		long double LWMA(0), sum_inverse_D(0), harmonic_mean_D(0), nextDifficulty(0);
 		int64_t solveTime(0);
 		uint64_t difficulty(0), next_difficulty(0);
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -260,6 +260,7 @@
 #define HF_VERSION_SLIPPAGE_V2                  24
 #define HF_VERSION_BURN                         24
 #define HF_VERSION_CONVERSION_FEES_NOT_BURNT_FINAL    24
+#define HF_VERSION_OFFSHORE_FEES_V3             24
 
 
 #define STAGENET_VERSION                        0x0e

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -256,6 +256,12 @@
 #define HF_VERSION_YIELD                        23
 #define HF_VERSION_CONVERSION_FEES_NOT_BURNT    23
 
+// Haven v4.1 definitions
+#define HF_VERSION_SLIPPAGE_V2                  24
+#define HF_VERSION_BURN                         24
+#define HF_VERSION_CONVERSION_FEES_NOT_BURNT_FINAL    24
+
+
 #define STAGENET_VERSION                        0x0e
 #define TESTNET_VERSION                         0x1b
 
@@ -263,6 +269,9 @@
 
 #define BURNT_CONVERSION_FEES_MINT_AMOUNT       ((uint64_t)2580000000000000000ull)
 #define BURNT_CONVERSION_FEES_MINT_HEIGHT       ((uint64_t)1656720)
+
+#define BURNT_CONVERSION_FEES_MINT_AMOUNT_FINAL       ((uint64_t)511812000000000000ull)
+#define BURNT_CONVERSION_FEES_MINT_HEIGHT_FINAL       ((uint64_t)1692002)
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 #define CRYPTONOTE_SCALING_2021_FEE_ROUNDING_PLACES 2

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -139,6 +139,7 @@
 #define BLOCKS_SYNCHRONIZING_MAX_COUNT                  2048   //must be a power of 2, greater than 128, equal to SEEDHASH_EPOCH_BLOCKS
 
 #define CRYPTONOTE_MEMPOOL_TX_LIVETIME                    86400  //seconds, one day
+#define CRYPTONOTE_MEMPOOL_TX_CONVERSION_LIVETIME         3600   //seconds, one hour
 #define CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME     604800 //seconds, one week
 
 

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -813,7 +813,7 @@ namespace cryptonote
       // Calculate the Mcap ratio slippage
       mcap_ratio_slippage = (hf_version < HF_VERSION_SLIPPAGE_V2) ? std::sqrt(std::pow(mcr_max.convert_to<double>(), 1.2)) / 6.0 : std::sqrt(std::pow(mcr_max.convert_to<double>(), 1.7)) / 3.0;
       //add-on for onshores, based on XHV price
-      if ((hf_version < HF_VERSION_SLIPPAGE_V2) && (tx_type == tt::ONSHORE)) {
+      if ((hf_version >= HF_VERSION_SLIPPAGE_V2) && (tx_type == tt::ONSHORE)) {
 
         uint128_t mraon_numerator = map_amounts["XHV"];
         uint128_t mraon_denominator = ((map_amounts["XUSD"] * pr.min("XHV"))/COIN)*100;
@@ -879,15 +879,15 @@ namespace cryptonote
     else {
       if (total_slippage > 0.99) total_slippage = 1.0;
       total_slippage=total_slippage*100.0;
-      uint128_t slippage_rounded_nominator=total_slippage.convert_to<uint128_t>();
-      slippage_rounded_nominator *=10;
-      if (slippage_rounded_nominator == 0) 
-        slippage_rounded_nominator=1;
-      if (slippage_rounded_nominator > 990) 
-        slippage_rounded_nominator=990;
+      uint128_t slippage_rounded_numerator=total_slippage.convert_to<uint128_t>();
+      slippage_rounded_numerator *=10;
+      if (slippage_rounded_numerator == 0) 
+        slippage_rounded_numerator=1;
+      if (slippage_rounded_numerator > 990) 
+        slippage_rounded_numerator=990;
       uint128_t slippage_rounded_denominator = 1000;
-      LOG_PRINT_L1("total_slippage (after rounding) = " << slippage_rounded_nominator<< "/1000");
-      uint128_t slippage_final_128 = (convert_amount*slippage_rounded_nominator)/slippage_rounded_denominator;
+      LOG_PRINT_L1("total_slippage (after rounding) = " << slippage_rounded_numerator<< "/1000");
+      uint128_t slippage_final_128 = (convert_amount*slippage_rounded_numerator)/slippage_rounded_denominator;
       slippage = slippage_final_128.convert_to<uint64_t>();
       slippage -= (slippage % 100000000);
     }

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -162,9 +162,12 @@ namespace cryptonote
 
       // HERE BE DRAGONS!!!
       // NEAC: mint the previously-burnt XHV conversion fees, and add to the governance wallet
+      
+      bool is_burnt_fee_mint_block = ((hard_fork_version == HF_VERSION_CONVERSION_FEES_NOT_BURNT) && (height == BURNT_CONVERSION_FEES_MINT_HEIGHT));
+      bool is_burnt_fee_mint_block_final = ((hard_fork_version == HF_VERSION_CONVERSION_FEES_NOT_BURNT_FINAL) && (height == BURNT_CONVERSION_FEES_MINT_HEIGHT_FINAL));
 
-      if (((hard_fork_version == HF_VERSION_CONVERSION_FEES_NOT_BURNT) && (height == BURNT_CONVERSION_FEES_MINT_HEIGHT)) || ((hard_fork_version == HF_VERSION_CONVERSION_FEES_NOT_BURNT_FINAL) && (height == BURNT_CONVERSION_FEES_MINT_HEIGHT_FINAL))){
-        uint64_t minted_due_to_burned_fees_bug = (hard_fork_version == HF_VERSION_CONVERSION_FEES_NOT_BURNT) ? BURNT_CONVERSION_FEES_MINT_AMOUNT : BURNT_CONVERSION_FEES_MINT_AMOUNT_FINAL;
+      if (is_burnt_fee_mint_block || is_burnt_fee_mint_block_final ){
+        uint64_t minted_due_to_burned_fees_bug = is_burnt_fee_mint_block ? BURNT_CONVERSION_FEES_MINT_AMOUNT : BURNT_CONVERSION_FEES_MINT_AMOUNT_FINAL;
         governance_reward += minted_due_to_burned_fees_bug;
       }
       // LAND AHOY!!!

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -1591,7 +1591,7 @@ namespace cryptonote
       }
 
       tx_out out;
-      cryptonote::set_tx_out(dst_entr.dest_amount*0, dst_entr.dest_asset_type, u_time, dst_entr.is_collateral, dst_entr.is_collateral_change, out_eph_public_key, use_view_tags, view_tag, out);
+      cryptonote::set_tx_out(dst_entr.dest_amount, dst_entr.dest_asset_type, u_time, dst_entr.is_collateral, dst_entr.is_collateral_change, out_eph_public_key, use_view_tags, view_tag, out);
       
       tx.vout.push_back(out);
       output_index++;
@@ -1602,10 +1602,8 @@ namespace cryptonote
           tx.amount_minted += dst_entr.dest_amount;
           tx.amount_burnt += dst_entr.amount + dst_entr.slippage;
         }
-      }  
+      }
     }
-
-    tx.amount_burnt=summary_outs_money;
 
     CHECK_AND_ASSERT_MES(additional_tx_public_keys.size() == additional_tx_keys.size(), false, "Internal error creating additional public keys");
 

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -311,9 +311,21 @@ namespace cryptonote
 
           // Add the conversion fee to the governance payment (if provided)
           if (offshore_fee_map[fee_map_entry.first] != 0) {
-            governance_reward_xasset += offshore_fee_map[fee_map_entry.first];
+            if (hard_fork_version >= HF_VERSION_OFFSHORE_FEES_V3) {
+              //split onshore/offshore fees 80% governance wallet, 20% miners
+              boost::multiprecision::uint128_t fee = offshore_fee_map[fee_map_entry.first];
+              boost::multiprecision::uint128_t fee_miner_xasset = fee / 5;
+              fee -= fee_miner_xasset;
+              // 80%
+              governance_reward_xasset += fee.convert_to<uint64_t>();
+              // 20%
+              block_reward_xasset += fee_miner_xasset.convert_to<uint64_t>();
+            } else
+            {
+              //Full conversion fee goes to the governance wallet before HF_VERSION_OFFSHORE_FEES_V3
+              governance_reward_xasset += offshore_fee_map[fee_map_entry.first];
+            }
           }
-          
           // handle xasset converion fees
           if (hard_fork_version >= HF_VERSION_XASSET_FEES_V2) {
             if (xasset_fee_map[fee_map_entry.first] != 0) {

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -900,6 +900,12 @@ namespace cryptonote
       LOG_ERROR("Invalid slippage amount (0) - aborting");
       return false;
     }
+
+    if (slippage > convert_amount) {
+      // Not a valid slippage amount
+      LOG_ERROR("Slippage higher than converted amount - aborting");
+      return false;
+    }
     
     return true;
   }

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -506,7 +506,7 @@ namespace cryptonote
         tvc.m_verifivation_failed = true;
         return false;
       }
-      if (hf_version >= HF_VERSION_BURN && tx.amount_minted) {
+      if ((hf_version >= HF_VERSION_BURN) && tx.amount_minted) {
         LOG_ERROR("error: Invalid Tx found. Amount mint > 0 for a transfer tx.");
         tvc.m_verifivation_failed = true;
         return false;

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1564,9 +1564,11 @@ namespace cryptonote
     std::list<std::pair<crypto::hash, uint64_t>> remove;
     m_blockchain.for_all_txpool_txes([this, &remove](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref*) {
       uint64_t tx_age = time(nullptr) - meta.receive_time;
+      bool has_conv_fee = (meta.offshore_fee > 0);
 
       if((tx_age > CRYPTONOTE_MEMPOOL_TX_LIVETIME && !meta.kept_by_block) ||
-         (tx_age > CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME && meta.kept_by_block) )
+         (tx_age > CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME && meta.kept_by_block) || 
+         (has_conv_fee && tx_age > CRYPTONOTE_MEMPOOL_TX_CONVERSION_LIVETIME && !meta.kept_by_block)) //Remove conversions faster, as their pricing record is outdated
       {
         LOG_PRINT_L1("Tx " << txid << " removed from tx pool due to outdated, age: " << tx_age );
         auto sorted_it = find_tx_in_sorted_container(txid);

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -499,12 +499,20 @@ namespace cryptonote
         return false;
       }
     } else {
-      // make sure there is no burnt/mint set for transfers, since these numbers will affect circulating supply.
-      if (tx.amount_burnt || tx.amount_minted) {
+      // make sure there is no burnt/mint set for transfers, unless it is a burn, since these numbers will affect circulating supply.
+
+      if ((tx.amount_burnt && hf_version<HF_VERSION_BURN)|| tx.amount_minted) {
         LOG_ERROR("error: Invalid Tx found. Amount burnt/mint > 0 for a transfer tx.");
         tvc.m_verifivation_failed = true;
         return false;
       }
+      if (hf_version >= HF_VERSION_BURN && tx.amount_minted) {
+        LOG_ERROR("error: Invalid Tx found. Amount mint > 0 for a transfer tx.");
+        tvc.m_verifivation_failed = true;
+        return false;
+      }
+
+
       // make sure no pr height set
       if (tx.pricing_record_height) {
         LOG_ERROR("error: Invalid Tx found. Tx pricing_record_height > 0 for a transfer tx.");

--- a/src/hardforks/hardforks.cpp
+++ b/src/hardforks/hardforks.cpp
@@ -49,7 +49,8 @@ const hardfork_t mainnet_hard_forks[] = {
   { 20, 1272875, 0, 1671618321 }, // Fork time is on or around 9th January 2023 at 10:00 GMT. Fork time finalised on 2022-12-21.
   { 21, 1439500, 0, 1690797000 }, // Fork time is on or around 29th August 2023 at 10:00 GMT. Fork time finalised on 2023-07-31.
   { 22, 1439544, 0, 1693999500 }, // Fork time is on or around 29th August 2023 at 12:05 GMT. Fork time finalised on 2023-09-06.
-  { 23, 1656000, 0, 1719672007 }  // Fork time is on or around 8th July 2024 at 09:00 GMT. Fork time finalised on 2024-06-29.
+  { 23, 1656000, 0, 1719672007 },  // Fork time is on or around 8th July 2024 at 09:00 GMT. Fork time finalised on 2024-06-29.
+  { 24, 1691182, 0, 1724716500 }  // Fork time is on or around 26th August 2024 at 23:55 GMT.
 };
 const size_t num_mainnet_hard_forks = sizeof(mainnet_hard_forks) / sizeof(mainnet_hard_forks[0]);
 const uint64_t mainnet_hard_fork_version_1_till = 1009826;
@@ -72,7 +73,8 @@ const hardfork_t testnet_hard_forks[] = {
   { 20, 100, 0, 1657094479 },
   { 21, 300, 0, 1680518049 },
   { 22, 400, 0, 1693999500 },
-  { 23, 450, 0, 1714641723 }
+  { 23, 450, 0, 1714641723 },
+  { 24, 500, 0, 1724716500 }
 };
 const size_t num_testnet_hard_forks = sizeof(testnet_hard_forks) / sizeof(testnet_hard_forks[0]);
 const uint64_t testnet_hard_fork_version_1_till = 624633;

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -1747,6 +1747,11 @@ namespace rct {
           LOG_ERROR("Failed to get output type");
           return false;
         }
+        
+        if (version >= HF_VERSION_ADDITIONAL_COLLATERAL_CHECKS && (is_collateral || is_collateral_change) && output_asset_type != "XHV"){
+          LOG_ERROR("Collateral which is not XHV found");
+          return false;  
+        }
 
         // Don't exclude the onshore collateral ouputs from proof-of-value calculation
         if (output_asset_type == strSource) {
@@ -1934,6 +1939,11 @@ namespace rct {
 
         if (version >= HF_VERSION_SLIPPAGE) {
           // Subtract the slippage from the amount_burnt
+          // Check for potential underflow and fail
+          if (amount_burnt<amount_slippage) {
+            LOG_ERROR("Slippage exceeds burnt amount");
+            return false; 
+          }
           amount_burnt -= amount_slippage;
         }
 

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -1700,7 +1700,23 @@ namespace rct {
             CHECK_AND_ASSERT_MES(amount_collateral, false, "0 collateral requirement something went wrong! rejecting tx..");
         }
       }
+
+      if (strSource == strDest) {
+        CHECK_AND_ASSERT_MES(pr.empty(), false, "Pricing record found for a transfer! rejecting tx..");
+        CHECK_AND_ASSERT_MES(amount_collateral==0, false, "Collateral found for a transfer! rejecting tx..");
+        CHECK_AND_ASSERT_MES(amount_slippage==0, false, "Slippage found for a transfer! rejecting tx..");
+        if (version < HF_VERSION_BURN) {
+          CHECK_AND_ASSERT_MES(amount_burnt==0, false, "amount_burnt found for a transfer tx! rejecting tx.. ");
+          }
+      }
       
+      uint64_t amount_supply_burnt = 0;
+
+      if ((tx_type == tt::TRANSFER || tx_type == tt::OFFSHORE_TRANSFER || tx_type == tt::XASSET_TRANSFER) && version >= HF_VERSION_BURN && amount_burnt>0){
+        amount_supply_burnt = amount_burnt;
+      }
+      
+
       // OUTPUTS SUMMED FOR EACH COLOUR
       key zerokey = rct::identity();
       // Zi is intentionally set to a different value to zerokey, so that if a bug is introduced in the later logic, any comparison with zerokey will fail
@@ -1776,6 +1792,8 @@ namespace rct {
       key txnFeeKey = scalarmultH(d2h(rv.txnFee));
       // Calculate offshore conversion fee (also always in C colour)
       key txnOffshoreFeeKey = scalarmultH(d2h(rv.txnOffshoreFee));
+      // Calculate the supply burn (also always in C colour)
+      key amount_supply_burntKey = scalarmultH(d2h(amount_supply_burnt));
 
       // Sum the consumed outputs in their respective asset types (sumColIns = inputs in D)
       key sumPseudoOuts = zerokey;
@@ -1803,6 +1821,9 @@ namespace rct {
       // Subtract the sum of converted output commitments from the sum of consumed output commitments in D colour (if any are present)
       // (Note: there are only consumed output commitments in D colour if the transaction is an onshore and requires collateral)
       subKeys(sumD, sumColIns, sumOutpks_D);
+
+      //Remove burnt supply
+      subKeys(sumC, sumC, amount_supply_burntKey);
 
       if (version >= HF_VERSION_CONVERSION_FEES_IN_XHV) {
         // NEAC: Convert the fees for conversions to XHV


### PR DESCRIPTION
This pull request delivers the following new features:

    Transfer validation now allows for a burn amount, which is permanently burnt and removed from the supply. The CLI functionality is not implemented yet. Proof of value is adjusted to ensure the amount is really burnt (inputs of a transfer minus fees minus amount burnt is equal to sum of outgoing amounts).
    Slippage formula adjustments

Issues fixed:

    Slippage is now rounded to 0.1%, 1%, 2%, 3%, ..., 99%, 99.9 - this should help with transactions getting stuck if they are not mined immediately
    Slippage is rounded up so that the remaining amount has maximum 4 non-zero digits after the decimal separator
    Conversions are removed from the pool after 1 hour
    Difficulty floating precision fix
    Minting of remaining incorrectly burnt XHV fees to the governance wallet, due to previous bug in conversion fees

Due to the changes in validation rules, a hardfork is necessary.
