### PR TITLE
initial implementation of burn in the CLI

### DIFF
--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -1537,6 +1537,12 @@ namespace cryptonote
     (tx_type == transaction_type::XUSD_TO_XASSET) ? get_xusd_to_xasset_fee(destinations, hf_version) :
     (tx_type == transaction_type::XASSET_TO_XUSD) ? get_xasset_to_xusd_fee(destinations, hf_version) : 0;
 
+    uint64_t supply_burnt = 0;
+
+    for(const tx_destination_entry& dst_entr: destinations) {
+      supply_burnt += dst_entr.supply_burnt;
+    }
+
     if (shuffle_outs)
     {
       std::shuffle(destinations.begin(), destinations.end(), crypto::random_device{});
@@ -1588,14 +1594,18 @@ namespace cryptonote
     //fill outputs
     size_t output_index = 0;
     uint64_t summary_outs_slippage = 0;
+    uint64_t summary_outs_supply_burn = 0;
+    
     for(const tx_destination_entry& dst_entr: destinations)
     {
       CHECK_AND_ASSERT_MES(dst_entr.dest_amount > 0 || tx.version > 1, false, "Destination with wrong amount: " << dst_entr.dest_amount);
+      CHECK_AND_ASSERT_MES(dst_entr.supply_burnt > 0 || tx.version < HF_VERSION_BURN, false, "Burn transaction before Haven 4.1");
       crypto::public_key out_eph_public_key;
       crypto::view_tag view_tag;
 
       // Sum all the slippage across the outputs
       summary_outs_slippage += dst_entr.slippage;
+      summary_outs_supply_burn += dst_entr.supply_burnt;
       
       hwdev.generate_output_ephemeral_keys(tx.version,sender_account_keys, txkey_pub, tx_key,
                                            dst_entr, change_addr, output_index,
@@ -1637,8 +1647,12 @@ namespace cryptonote
           tx.amount_minted += dst_entr.dest_amount;
           tx.amount_burnt += dst_entr.amount + dst_entr.slippage;
         }
+      } else {
+          tx.amount_burnt += dst_entr.supply_burnt;
       }
     }
+
+
 
     CHECK_AND_ASSERT_MES(additional_tx_public_keys.size() == additional_tx_keys.size(), false, "Internal error creating additional public keys");
 
@@ -1847,7 +1861,7 @@ namespace cryptonote
       if (!use_simple_rct && amount_in > amount_out)
         outamounts.push_back(amount_in - amount_out);
       else
-        fee = summary_inputs_money - summary_outs_money - offshore_fee;
+        fee = summary_inputs_money - summary_outs_money - offshore_fee - supply_burnt;
       
       // since the col ins are added to the summary_inputs_money above for offshores, subtract it.
       if (tx_type == transaction_type::OFFSHORE && hf_version >= HF_VERSION_USE_COLLATERAL) {

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -1599,7 +1599,7 @@ namespace cryptonote
     for(const tx_destination_entry& dst_entr: destinations)
     {
       CHECK_AND_ASSERT_MES(dst_entr.dest_amount > 0 || tx.version > 1, false, "Destination with wrong amount: " << dst_entr.dest_amount);
-      CHECK_AND_ASSERT_MES(dst_entr.supply_burnt > 0 || tx.version < HF_VERSION_BURN, false, "Burn transaction before Haven 4.1");
+      CHECK_AND_ASSERT_MES(dst_entr.supply_burnt == 0 || hf_version >= HF_VERSION_BURN, false, "Burn transaction before Haven 4.1");
       crypto::public_key out_eph_public_key;
       crypto::view_tag view_tag;
 

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -106,6 +106,7 @@ namespace cryptonote
     uint64_t amount;              // destination money in source asset
     uint64_t dest_amount;         // destination money in dest asset
     uint64_t slippage;            // destination money in source asset that will be burnt as slippage
+    uint64_t supply_burnt;            // amount of source asset to be permanently burnt as part of a transfer
     std::string dest_asset_type;  // destination asset type
     account_public_address addr;  // destination address
     bool is_subaddress;
@@ -113,10 +114,10 @@ namespace cryptonote
     bool is_collateral;
     bool is_collateral_change;
 
-    tx_destination_entry() : amount(0), dest_amount(0), slippage(0), addr(AUTO_VAL_INIT(addr)), is_subaddress(false), is_integrated(false), is_collateral(false), is_collateral_change(false), dest_asset_type("XHV") { }
-    tx_destination_entry(uint64_t a, const account_public_address &ad, bool is_subaddress, bool is_collateral, bool is_collateral_change) : amount(a), dest_amount(a), slippage(0), addr(ad), is_subaddress(is_subaddress), is_integrated(false), is_collateral(is_collateral), is_collateral_change(is_collateral_change), dest_asset_type("XHV") { }
-    tx_destination_entry(uint64_t a, const account_public_address &ad, bool is_subaddress) : amount(a), slippage(0), addr(ad), is_subaddress(is_subaddress), is_integrated(false), is_collateral(false), is_collateral_change(false), dest_asset_type("XHV") { }
-    tx_destination_entry(const std::string &o, uint64_t a, const account_public_address &ad, bool is_subaddress) : original(o), amount(a), slippage(0), addr(ad), is_subaddress(is_subaddress), is_integrated(false), is_collateral(false), is_collateral_change(false), dest_asset_type("XHV") { }
+    tx_destination_entry() : amount(0), dest_amount(0), slippage(0), supply_burnt(0), addr(AUTO_VAL_INIT(addr)), is_subaddress(false), is_integrated(false), is_collateral(false), is_collateral_change(false), dest_asset_type("XHV") { }
+    tx_destination_entry(uint64_t a, const account_public_address &ad, bool is_subaddress, bool is_collateral, bool is_collateral_change) : amount(a), dest_amount(a), slippage(0), supply_burnt(0), addr(ad), is_subaddress(is_subaddress), is_integrated(false), is_collateral(is_collateral), is_collateral_change(is_collateral_change), dest_asset_type("XHV") { }
+    tx_destination_entry(uint64_t a, const account_public_address &ad, bool is_subaddress) : amount(a), slippage(0), supply_burnt(0), addr(ad), is_subaddress(is_subaddress), is_integrated(false), is_collateral(false), is_collateral_change(false), dest_asset_type("XHV") { }
+    tx_destination_entry(const std::string &o, uint64_t a, const account_public_address &ad, bool is_subaddress) : original(o), amount(a), slippage(0), supply_burnt(0), addr(ad), is_subaddress(is_subaddress), is_integrated(false), is_collateral(false), is_collateral_change(false), dest_asset_type("XHV") { }
 
     std::string address(network_type nettype, const crypto::hash &payment_id) const
     {
@@ -138,6 +139,7 @@ namespace cryptonote
       VARINT_FIELD(amount)
       VARINT_FIELD(dest_amount)
       VARINT_FIELD(slippage)
+      //VARINT_FIELD(supply_burnt)
       FIELD(dest_asset_type)
       FIELD(addr)
       FIELD(is_subaddress)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -156,9 +156,23 @@ typedef cryptonote::simple_wallet sw;
     } \
   } while(0)
 
+#define CHECK_BURN_ENABLED() \
+  do \
+  { \
+    if (!m_wallet->is_burn_enabled()) \
+    { \
+      fail_msg_writer() << tr("Burn is disabled."); \
+      fail_msg_writer() << tr("Burn is an experimental feature and may have bugs. Things that could go wrong include: loss of entire funds in the wallet, corruption of wallet."); \
+      fail_msg_writer() << tr("You can enable it with:"); \
+      fail_msg_writer() << tr("  set enable-burn-experimental 1"); \
+      return false; \
+    } \
+  } while(0)
+
 enum TransferType {
   Transfer,
   TransferLocked,
+  TransferBurn,
 };
 
 static std::string get_human_readable_timespan(std::chrono::seconds seconds);
@@ -198,11 +212,14 @@ namespace
   const char* USAGE_PAYMENTS("payments <PID_1> [<PID_2> ... <PID_N>]");
   const char* USAGE_PAYMENT_ID("payment_id");
   const char* USAGE_TRANSFER("transfer [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] (<URI> | <address> <amount>) [<payment_id>]");
+  const char* USAGE_TRANSFER_BURN("transfer_burn [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] (<URI> | <address> <amount> <burn amount>) [<payment_id>]");
   const char* USAGE_LOCKED_TRANSFER("locked_transfer [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] (<URI> | <addr> <amount>) <lockblocks> [<payment_id (obsolete)>]");
   const char* USAGE_OFFSHORE("offshore [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] (<URI> | <address> <XHV amount> [memo=<memo data>])");
   const char* USAGE_OFFSHORE_TRANSFER("offshore_transfer [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] (<URI> | <address> <xUSD amount> [memo=<memo data>])");
+  const char* USAGE_OFFSHORE_TRANSFER_BURN("offshore_transfer_burn [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] (<URI> | <address> <xUSD amount> <xUSD burn amount>[memo=<memo data>])");
   const char* USAGE_ONSHORE("onshore [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] (<URI> | <address> <xUSD amount> [memo=<memo data>])");
   const char* USAGE_XASSET_TRANSFER("xasset_transfer [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] (<URI> | <address> <xAsset amount>) <xAsset type> [memo=<memo data>]");
+  const char* USAGE_XASSET_TRANSFER_BURN("xasset_transfer_burn [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] (<URI> | <address> <xAsset amount>) <xAsset burn amount> <xAsset type> [memo=<memo data>]");
   const char* USAGE_XASSET_TO_XUSD("xasset_to_xusd [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] (<URI> | <address> <xAsset amount>) <xAsset type> [memo=<memo data>]");
   const char* USAGE_XUSD_TO_XASSET("xusd_to_xasset [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] (<URI> | <address> <xUSD amount>) <xAsset type> [memo=<memo data>]");
   const char* USAGE_LOCKED_SWEEP_ALL("locked_sweep_all [index=<N1>[,<N2>,...] | index=all] [<priority>] [<ring_size>] <address> <lockblocks> [<payment_id (obsolete)>]");
@@ -3139,6 +3156,25 @@ bool simple_wallet::set_enable_multisig(const std::vector<std::string> &args/* =
   return true;
 }
 
+bool simple_wallet::set_enable_burn(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
+{
+  if (args.size() < 2)
+  {
+    fail_msg_writer() << tr("Value not specified");
+    return true;
+  }
+
+  const auto pwd_container = get_and_verify_password();
+  if (pwd_container)
+  {
+    parse_bool_and_use(args[1], [&](bool r) {
+      m_wallet->enable_burn(r);
+      m_wallet->rewrite(m_wallet_file, pwd_container->password());
+    });
+  }
+  return true;
+}
+
 bool simple_wallet::help(const std::vector<std::string> &args/* = std::vector<std::string>()*/)
 {
   if(args.empty())
@@ -3310,6 +3346,9 @@ simple_wallet::simple_wallet()
   m_cmd_binder.set_handler("transfer", boost::bind(&simple_wallet::on_command, this, &simple_wallet::transfer, _1),
                            tr(USAGE_TRANSFER),
                            tr("Transfer <amount> to <address>. If the parameter \"index=<N1>[,<N2>,...]\" is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. <priority> is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. <ring_size> is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or <address_2> <amount_2> etcetera (before the payment ID, if it's included)"));
+  m_cmd_binder.set_handler("transfer_burn", boost::bind(&simple_wallet::on_command, this, &simple_wallet::transfer_burn, _1),
+                           tr(USAGE_TRANSFER_BURN),
+                           tr("Transfer <amount> to <address>, burning <burn amount>. If the parameter \"index=<N1>[,<N2>,...]\" is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. <priority> is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. <ring_size> is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or <address_2> <amount_2> etcetera (before the payment ID, if it's included)"));
   m_cmd_binder.set_handler("locked_transfer",
                            boost::bind(&simple_wallet::on_command, this, &simple_wallet::locked_transfer,_1),
                            tr(USAGE_LOCKED_TRANSFER),
@@ -3322,6 +3361,10 @@ simple_wallet::simple_wallet()
                            boost::bind(&simple_wallet::offshore_transfer, this, _1),
                            tr(USAGE_OFFSHORE_TRANSFER),
                            tr("Transfer <amount> xUSD from current offshore balance to <address>. If the parameter \"index=<N1>[,<N2>,...]\" is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. <priority> is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. <ring_size> is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or <address_2> <amount_2> etcetera (before the payment ID, if it's included)"));
+  m_cmd_binder.set_handler("offshore_transfer_burn",
+                           boost::bind(&simple_wallet::offshore_transfer_burn, this, _1),
+                           tr(USAGE_OFFSHORE_TRANSFER_BURN),
+                           tr("Transfer <amount> xUSD and burn <burn amount> from current offshore balance to <address>. If the parameter \"index=<N1>[,<N2>,...]\" is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. <priority> is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. <ring_size> is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or <address_2> <amount_2> etcetera (before the payment ID, if it's included)")); 
   m_cmd_binder.set_handler("onshore",
                            boost::bind(&simple_wallet::onshore, this, _1),
                            tr(USAGE_ONSHORE),
@@ -3330,6 +3373,10 @@ simple_wallet::simple_wallet()
                            boost::bind(&simple_wallet::xasset_transfer, this, _1),
                            tr(USAGE_XASSET_TRANSFER),
                            tr("Transfer <xAsset amount> of xAsset type <xAsset type> from current balance to <address>. If the parameter \"index=<N1>[,<N2>,...]\" is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. <priority> is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. <ring_size> is the number of inputs to include for untraceability. Multiple payments can be made (using the same asset type) at once by adding URI_2 or <address_2> <amount_2> etcetera (before the payment ID, if it's included). If <memo data> is provided, only 1 destination address / URI may be specified."));
+  m_cmd_binder.set_handler("xasset_transfer_burn",
+                           boost::bind(&simple_wallet::xasset_transfer_burn, this, _1),
+                           tr(USAGE_XASSET_TRANSFER_BURN),
+                           tr("Transfer <xAsset amount> and burn <burn amount> of xAsset type <xAsset type> from current balance to <address>. If the parameter \"index=<N1>[,<N2>,...]\" is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. <priority> is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command \"set priority\") is used. <ring_size> is the number of inputs to include for untraceability. Multiple payments can be made (using the same asset type) at once by adding URI_2 or <address_2> <amount_2> etcetera (before the payment ID, if it's included). If <memo data> is provided, only 1 destination address / URI may be specified."));
   m_cmd_binder.set_handler("xasset_to_xusd",
                            boost::bind(&simple_wallet::xasset_to_xusd, this, _1),
                            tr(USAGE_XASSET_TO_XUSD),
@@ -3514,6 +3561,8 @@ simple_wallet::simple_wallet()
                                   "  Set this if you would like to display the wallet name when locked.\n "
                                   "enable-multisig-experimental <1|0>\n "
                                   "  Set this to allow multisig commands. Multisig may currently be exploitable if parties do not trust each other.\n "
+                                  "enable-burn-experimental <1|0>\n "
+                                  "  Set this to allow burning of funds. This feature can result in complete funds loss. Do not use.\n "
                                   "inactivity-lock-timeout <unsigned int>\n "
                                   "  How many seconds to wait before locking the wallet (0 to disable)."));
   m_cmd_binder.set_handler("encrypted_seed",
@@ -3997,6 +4046,7 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
     CHECK_SIMPLE_VARIABLE("auto-mine-for-rpc-payment-threshold", set_auto_mine_for_rpc_payment_threshold, tr("floating point >= 0"));
     CHECK_SIMPLE_VARIABLE("credits-target", set_credits_target, tr("unsigned integer"));
     CHECK_SIMPLE_VARIABLE("enable-multisig-experimental", set_enable_multisig, tr("0 or 1"));
+    CHECK_SIMPLE_VARIABLE("enable-burn-experimental", set_enable_burn, tr("0 or 1"));
   }
   fail_msg_writer() << tr("set: unrecognized argument(s)");
   return true;
@@ -6703,6 +6753,9 @@ bool simple_wallet::transfer_main(
   bool called_by_mms
 ){
 
+  if (transfer_type == TransferBurn){
+    CHECK_BURN_ENABLED();
+  }
   //  "transfer [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] <address> <amount> [<payment_id>]"
   if (!try_connect_to_daemon())
     return false;
@@ -6753,7 +6806,7 @@ bool simple_wallet::transfer_main(
     return false;
   }
 
-  const size_t min_args = (transfer_type == TransferLocked) ? 2 : 1;
+  const size_t min_args = (transfer_type == TransferLocked) ? 2 : (transfer_type == TransferBurn) ? 2 : 1;
   if(local_args.size() < min_args)
   {
      fail_msg_writer() << tr("wrong number of arguments");
@@ -6798,7 +6851,33 @@ bool simple_wallet::transfer_main(
     local_args.pop_back();
   }
 
-  // check fot blocked xjpy
+  uint64_t amount_supply_burnt = 0;
+  bool amount_supply_burnt_applied = false;
+  if (transfer_type == TransferBurn)
+  {
+      // check if burn is allowed
+    CHECK_BURN_ENABLED();
+    if (!m_wallet->use_fork_rules(HF_VERSION_BURN, 0)) {
+        fail_msg_writer() << tr("Burn transactions not allowed before Haven 4.1");
+        return false;
+    }
+    try
+    {
+      bool ok = cryptonote::parse_amount(amount_supply_burnt, local_args.back());
+      if (!ok) {
+        fail_msg_writer() << tr("bad <burn amount> parameter:") << " " << local_args.back();
+        return false;  
+      }
+    }
+    catch (const std::exception &e)
+    {
+      fail_msg_writer() << tr("bad <burn amount> parameter:") << " " << local_args.back();
+      return false;
+    }
+    local_args.pop_back();
+  }
+
+  // check for blocked xjpy
   if (m_wallet->use_fork_rules(HF_VERSION_HAVEN2, 0)) {
     if (source_asset == "XJPY" || dest_asset == "XJPY") {
       fail_msg_writer() << tr("XJPY transaction are disabled after haven2 fork.");
@@ -6846,6 +6925,11 @@ bool simple_wallet::transfer_main(
     bool has_uri = m_wallet->parse_uri(local_args[i], address_uri, payment_id_uri, amount, tx_description, recipient_name, unknown_parameters, error);
     if (has_uri)
     {
+        if (amount_supply_burnt>0)
+        {
+          fail_msg_writer() << tr("URI not supported for burn transactions");
+          return false;
+        }
       r = cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), address_uri, oa_prompter);
       if (payment_id_uri.size() == 16)
       {
@@ -6874,6 +6958,11 @@ bool simple_wallet::transfer_main(
             fail_msg_writer() << tr("failed to get max destination amount: ") << err;
             return false;
           }
+        if (amount_supply_burnt > 0)
+        {
+          fail_msg_writer() << tr("usage of max not supported for burn transactions");
+          return false;
+        }
           de.amount = amount;
         } else {
           fail_msg_writer() << tr("amount is wrong: ") << local_args[i] << ' ' << local_args[i + 1] <<
@@ -6882,6 +6971,10 @@ bool simple_wallet::transfer_main(
         }
       }
       de.original = local_args[i];
+      if (amount_supply_burnt>0 && !amount_supply_burnt_applied){
+        de.supply_burnt=amount_supply_burnt;
+        amount_supply_burnt_applied=true;
+      }
       i += 2;
     }
     else
@@ -6964,6 +7057,9 @@ bool simple_wallet::transfer_main(
       case Transfer:
         ptx_vector = m_wallet->create_transactions_2(dsts, source_asset, fake_outs_count, 0 /* unlock_time */, priority, extra, m_current_subaddress_account, subaddr_indices);
       break;
+      case TransferBurn:
+        ptx_vector = m_wallet->create_transactions_2(dsts, source_asset, fake_outs_count, 0 /* unlock_time */, priority, extra, m_current_subaddress_account, subaddr_indices);
+      break;
     }
 
     if (ptx_vector.empty())
@@ -7034,6 +7130,7 @@ bool simple_wallet::transfer_main(
         uint64_t total_col = 0;
         uint64_t total_slippage = 0;
         uint64_t total_tx_fee = 0;
+        uint64_t total_suppy_burnt = 0;
         uint64_t total_offshore_fee = 0;
         uint64_t dust_not_in_fee = 0;
         uint64_t dust_in_fee = 0;
@@ -7041,6 +7138,8 @@ bool simple_wallet::transfer_main(
         for (size_t n = 0; n < ptx_vector.size(); ++n)
         {
           total_tx_fee += ptx_vector[n].tx.rct_signatures.txnFee;
+          if (tx_type == tt::TRANSFER || tx_type == tt::OFFSHORE_TRANSFER || tx_type == tt::XASSET_TRANSFER)
+            total_suppy_burnt += ptx_vector[n].tx.amount_burnt;
           total_offshore_fee += ptx_vector[n].tx.rct_signatures.txnOffshoreFee;
           for (auto i: ptx_vector[n].selected_transfers)
             if (m_wallet->get_transfer_details(i).asset_type == source_asset)
@@ -7080,7 +7179,13 @@ bool simple_wallet::transfer_main(
         }
         uint64_t conversion_fee_in_C = total_offshore_fee;
         if (source_asset == dest_asset) {
-          prompt << boost::format(tr("Sending %s %s.\n")) % print_money(total_sent) % source_asset;
+          prompt << boost::format(tr("Sending %s %s.\n")) % print_money(total_sent-total_suppy_burnt) % source_asset;
+          if (total_suppy_burnt > 0) {
+            message_writer(console_color_red, false) << boost::format(tr("WARNING WARNING WARNING !!!.\n"));
+            message_writer(console_color_red, false) << boost::format(tr("PERMANENTLY DESTROYING %s %s , MAKE SURE THIS IS INTENTIONAL !!!.\n")) % print_money(total_suppy_burnt) % source_asset;
+            message_writer(console_color_red, false) << boost::format(tr("ABORT IMMEDIATELLY UNLESS ABSOLUTELY CERTAIN !!!.\n"));
+            prompt << boost::format(tr("!!!! PERMANENTLY DESTROYING %s %s , MAKE SURE THIS IS INTENTIONAL !!!.\n")) % print_money(total_suppy_burnt) % source_asset;
+          }
         } else {
           double total_slippage_pct = double(total_slippage) / double(total_sent) * 100;
           switch (tx_type)
@@ -7278,6 +7383,18 @@ bool simple_wallet::transfer(const std::vector<std::string> &args_)
   return true;
 }
 //----------------------------------------------------------------------------------------------------
+bool simple_wallet::transfer_burn(const std::vector<std::string> &args_)
+{
+  CHECK_BURN_ENABLED();
+  if (args_.size() < 2)
+  {
+    PRINT_USAGE(USAGE_TRANSFER_BURN);
+    return true;
+  }
+  transfer_main(TransferBurn, "XHV", "XHV", args_, false);
+  return true;
+}
+//----------------------------------------------------------------------------------------------------
 bool simple_wallet::locked_transfer(const std::vector<std::string> &args_)
 {
   if (args_.size() < 1)
@@ -7323,6 +7440,18 @@ bool simple_wallet::offshore_transfer(const std::vector<std::string> &args_)
   return true;
 }
 //----------------------------------------------------------------------------------------------------
+bool simple_wallet::offshore_transfer_burn(const std::vector<std::string> &args_)
+{
+  CHECK_BURN_ENABLED();
+  if (args_.size() < 3)
+  {
+    PRINT_USAGE(USAGE_OFFSHORE_TRANSFER_BURN);
+    return true;
+  }
+  transfer_main(TransferBurn, "XUSD", "XUSD", args_, false);
+  return true;
+}
+//----------------------------------------------------------------------------------------------------
 bool simple_wallet::xasset_to_xusd(const std::vector<std::string> &args_)
 {
   // Verify the arguments provided
@@ -7353,6 +7482,7 @@ bool simple_wallet::xasset_to_xusd(const std::vector<std::string> &args_)
   transfer_main(Transfer, source_asset, "XUSD", local_args, false);
   return true;
 }
+//----------------------------------------------------------------------------------------------------
 bool simple_wallet::xasset_transfer(const std::vector<std::string> &args)
 {
   // Verify the arguments provided
@@ -7381,6 +7511,38 @@ bool simple_wallet::xasset_transfer(const std::vector<std::string> &args)
   local_args.erase(local_args.end() - 1);
 
   transfer_main(Transfer, asset, asset, local_args, false);
+  return true;
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::xasset_transfer_burn(const std::vector<std::string> &args)
+{
+  CHECK_BURN_ENABLED();
+  // Verify the arguments provided
+  if (args.size() < 4) {
+    PRINT_USAGE(USAGE_XASSET_TRANSFER_BURN);
+    return true;
+  }
+  
+  // copy args
+  std::vector<std::string> local_args = args;
+
+  // check and remove the asset type
+  std::string asset = boost::algorithm::to_upper_copy(*(local_args.end() - 1));
+  if (std::find(offshore::ASSET_TYPES.begin(), offshore::ASSET_TYPES.end(), asset) == offshore::ASSET_TYPES.end()) {
+    fail_msg_writer() << boost::format(tr("Invalid currency '%s' specified")) % asset;
+    return false;
+  }
+  if (asset == "XUSD") {
+    fail_msg_writer() << "xasset_transfer_burn command is only for xAssets. You have to use 'offshore_transfer_burn' command to burn your xUSD.";
+    return false;
+  }
+  if (asset == "XHV") {
+    fail_msg_writer() << "xasset_transfer_burn command is only for xAssets. You have to use 'transfer_burn' command to burn your XHV.";
+    return false;
+  }
+  local_args.erase(local_args.end() - 1);
+
+  transfer_main(TransferBurn, asset, asset, local_args, false);
   return true;
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -152,6 +152,7 @@ namespace cryptonote
     bool set_export_format(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_load_deprecated_formats(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_enable_multisig(const std::vector<std::string> &args = std::vector<std::string>());
+    bool set_enable_burn(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_persistent_rpc_client_id(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_auto_mine_for_rpc_payment_threshold(const std::vector<std::string> &args = std::vector<std::string>());
     bool set_credits_target(const std::vector<std::string> &args = std::vector<std::string>());
@@ -170,12 +171,15 @@ namespace cryptonote
     bool show_blockchain_height(const std::vector<std::string> &args);
     bool transfer_main(int transfer_type, const std::string& source_asset, const std::string& dest_asset, const std::vector<std::string> &args, bool called_by_mms);
     bool transfer(const std::vector<std::string> &args);
+    bool transfer_burn(const std::vector<std::string> &args);
     bool offshore(const std::vector<std::string> &args);
     bool onshore(const std::vector<std::string> &args);
     bool offshore_transfer(const std::vector<std::string> &args);
+    bool offshore_transfer_burn(const std::vector<std::string> &args);
     bool xusd_to_xasset(const std::vector<std::string> &args);
     bool xasset_to_xusd(const std::vector<std::string> &args);
     bool xasset_transfer(const std::vector<std::string> &args);
+    bool xasset_transfer_burn(const std::vector<std::string> &args);
     bool locked_transfer(const std::vector<std::string> &args);
     bool locked_sweep_all(const std::vector<std::string> &args);
     bool sweep_main(uint32_t account, uint64_t below, bool locked, const std::vector<std::string> &args);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1449,7 +1449,9 @@ private:
     uint64_t credits_target() const { return m_credits_target; }
     void credits_target(uint64_t threshold) { m_credits_target = threshold; }
     bool is_multisig_enabled() const { return m_enable_multisig; }
+    bool is_burn_enabled() const { return m_enable_burn; }
     void enable_multisig(bool enable) { m_enable_multisig = enable; }
+    void enable_burn(bool enable) { m_enable_burn = enable; }
     bool is_mismatched_daemon_version_allowed() const { return m_allow_mismatched_daemon_version; }
     void allow_mismatched_daemon_version(bool allow_mismatch) { m_allow_mismatched_daemon_version = allow_mismatch; }
 
@@ -1976,6 +1978,7 @@ private:
     rpc_payment_state_t m_rpc_payment_state;
     uint64_t m_credits_target;
     bool m_enable_multisig;
+    bool m_enable_burn;
     bool m_allow_mismatched_daemon_version;
 
     // Aux transaction data from device


### PR DESCRIPTION
Initial implementation of the following commands in the CLI:

transfer_burn
offshore_transfer_burn
xasset_transfer_burn

Added a new wallet parameter enable-burn-experimental, which is intentionally not saved and always initialized as "false". It has to be manually enabled in each CLI session in order to allow burn transactions.