### PR TITLE
Haven 4.2 - Wallet Fixes, Supply recalculation, Lock times changes

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -36,6 +36,7 @@
 #include <cstring>  // memcpy
 
 #include "cryptonote_config.h"
+#include "cryptonote_core/cryptonote_tx_utils.h"
 #include "string_tools.h"
 #include "file_io_utils.h"
 #include "common/util.h"
@@ -1113,6 +1114,8 @@ uint64_t BlockchainLMDB::add_transaction_data(const crypto::hash& blk_hash, cons
   // NEAC : check for presence of offshore TX to see if we need to update circulating supply information
   // Tay8NWWFKpz9JT4NXU0w: Also burn transactions affect the supply
   uint64_t fee_in_XHV=0;
+  uint64_t fee_in_strSource=0;
+  
   if ((tx.version >= OFFSHORE_TRANSACTION_VERSION) && (is_mint_and_burn_tx || is_burn_tx)) {  
     // Offshore TX - update our records
     circ_supply cs;
@@ -1123,7 +1126,23 @@ uint64_t BlockchainLMDB::add_transaction_data(const crypto::hash& blk_hash, cons
     cs.amount_burnt = tx.amount_burnt;
     if(m_height>=SUPPLY_AUDIT_BLOCK_HEIGHT && is_mint_and_burn_tx){ //Fees are in XHV, so have to be removed from the supply. This is actually a bug from earlier, but only discovered during the supply audit.
       fee_in_XHV=tx.rct_signatures.txnFee + tx.rct_signatures.txnOffshoreFee;
-      cs.amount_burnt+=fee_in_XHV;
+      crypto::hash pricing_block_hash=get_block_hash_from_height(tx.pricing_record_height);
+      block_header pricing_block=get_block_header(pricing_block_hash);
+      uint8_t hf_version = get_hard_fork_version(tx.pricing_record_height);
+      uint64_t conversion_rate = 0;
+      if (!cryptonote::get_conversion_rate(pricing_block.pricing_record, "XHV", strSource, conversion_rate, hf_version)){
+        LOG_PRINT_L2("Failed to get conversition rate for transaction " << tx.hash << " total supply will not account properly for fees in XHV");
+      } else {
+          boost::multiprecision::uint128_t tx_fee_128 = tx.rct_signatures.txnFee; // Fee stored in XHV
+          tx_fee_128 *= conversion_rate;
+          tx_fee_128 /= COIN;
+          boost::multiprecision::uint128_t conversion_fee_128 = tx.rct_signatures.txnOffshoreFee; // Fee stored in XHV
+          conversion_fee_128 *= conversion_rate;
+          conversion_fee_128 /= COIN;
+          fee_in_strSource += tx_fee_128.convert_to<uint64_t>();
+          fee_in_strSource += conversion_fee_128.convert_to<uint64_t>();
+          cs.amount_burnt+=fee_in_strSource;
+      }
     }
     cs.amount_minted = tx.amount_minted;
     MDB_val_set(val_circ_supply, cs);
@@ -1248,9 +1267,27 @@ void BlockchainLMDB::remove_transaction_data(const crypto::hash& tx_hash, const 
     cs.pricing_record_height = tx.pricing_record_height;
     cs.amount_burnt = tx.amount_burnt;
     uint64_t fee_in_XHV = 0;
+    uint64_t fee_in_strSource=0;
+  
     if(m_height>=SUPPLY_AUDIT_BLOCK_HEIGHT && is_mint_and_burn_tx){ //Fees are in XHV, so have to be removed from the supply. This is actually a bug from earlier, but only discovered during the supply audit.
       fee_in_XHV=tx.rct_signatures.txnFee + tx.rct_signatures.txnOffshoreFee;
-      cs.amount_burnt+=fee_in_XHV;
+      crypto::hash pricing_block_hash=get_block_hash_from_height(tx.pricing_record_height);
+      block_header pricing_block=get_block_header(pricing_block_hash);
+      uint8_t hf_version = get_hard_fork_version(tx.pricing_record_height);
+      uint64_t conversion_rate = 0;
+      if (!cryptonote::get_conversion_rate(pricing_block.pricing_record, "XHV", strSource, conversion_rate, hf_version)){
+        LOG_PRINT_L2("Failed to get conversition rate for transaction " << tx.hash << " total supply will not account properly for fees in XHV");
+      } else {
+          boost::multiprecision::uint128_t tx_fee_128 = tx.rct_signatures.txnFee; // Fee stored in XHV
+          tx_fee_128 *= conversion_rate;
+          tx_fee_128 /= COIN;
+          boost::multiprecision::uint128_t conversion_fee_128 = tx.rct_signatures.txnOffshoreFee; // Fee stored in XHV
+          conversion_fee_128 *= conversion_rate;
+          conversion_fee_128 /= COIN;
+          fee_in_strSource += tx_fee_128.convert_to<uint64_t>();
+          fee_in_strSource += conversion_fee_128.convert_to<uint64_t>();
+          cs.amount_burnt+=fee_in_strSource;
+      }
     }
     cs.amount_minted = tx.amount_minted;
     cs.source_currency_type = std::find(offshore::ASSET_TYPES.begin(), offshore::ASSET_TYPES.end(), strSource) - offshore::ASSET_TYPES.begin();
@@ -3419,20 +3456,53 @@ void BlockchainLMDB::recalculate_supply_after_audit(const rct::key & decryption_
           }
           amount_decrypted ^= encryption_key; //XOR using the encryption key
 
-          MDEBUG("height,amount_decrypted,tx: " << height<<","<<amount_decrypted<<","<<tx_hash);
+          MDEBUG("height: "<< height <<"audit of " << print_money(amount_decrypted) << strDest);
           uint64_t dest_currency_type = std::find(offshore::ASSET_TYPES.begin(), offshore::ASSET_TYPES.end(), strDest) - offshore::ASSET_TYPES.begin();
           total_new_supply[dest_currency_type] += amount_decrypted; //Sum of outgoing amounts
-        } else { //check if we already have a transaction record
-            MDB_val v;
-            result = mdb_cursor_get(m_cur_circ_supply, &val_tx_id, &v, MDB_SET);
-            if (result==0){
-              const circ_supply &cs = *(const circ_supply*)v.mv_data;
-              boost::multiprecision::int128_t burnt = cs.amount_burnt;
-              total_new_supply[cs.source_currency_type] -= burnt;
-              boost::multiprecision::int128_t minted = cs.amount_minted;
-              total_new_supply[cs.dest_currency_type] += minted;
-            } else if(result != MDB_NOTFOUND)
-                throw0(DB_ERROR(lmdb_error("Failed to enumerate circ_supply table: ", result).c_str()));
+        } else { 
+            bool is_mint_and_burn_tx = (strSource != strDest);
+            bool is_burn_tx = (strSource == strDest) && tx.amount_burnt > 0;
+            uint64_t fee_in_XHV=0;
+            uint64_t fee_in_strSource=0;
+            
+            if ((tx.version >= OFFSHORE_TRANSACTION_VERSION) && (is_mint_and_burn_tx || is_burn_tx)) {
+              // Offshore TX - update our records
+              circ_supply cs;
+              cs.tx_hash = tx_hash;
+              cs.pricing_record_height = tx.pricing_record_height;
+              cs.source_currency_type = std::find(offshore::ASSET_TYPES.begin(), offshore::ASSET_TYPES.end(), strSource) - offshore::ASSET_TYPES.begin();
+              cs.dest_currency_type = std::find(offshore::ASSET_TYPES.begin(), offshore::ASSET_TYPES.end(), strDest) - offshore::ASSET_TYPES.begin();
+              uint64_t XHV_currency_type_id = std::find(offshore::ASSET_TYPES.begin(), offshore::ASSET_TYPES.end(), "XHV") - offshore::ASSET_TYPES.begin();
+              
+              cs.amount_burnt = tx.amount_burnt;
+              if(height>=SUPPLY_AUDIT_BLOCK_HEIGHT && is_mint_and_burn_tx){ //Fees are in XHV, so have to be removed from the supply. This is actually a bug from earlier, but only discovered during the supply audit.
+                fee_in_XHV=tx.rct_signatures.txnFee + tx.rct_signatures.txnOffshoreFee;
+                crypto::hash pricing_block_hash=get_block_hash_from_height(tx.pricing_record_height);
+                block_header pricing_block=get_block_header(pricing_block_hash);
+                uint8_t hf_version = get_hard_fork_version(tx.pricing_record_height);
+                uint64_t conversion_rate = 0;
+                if (!cryptonote::get_conversion_rate(pricing_block.pricing_record, "XHV", strSource , conversion_rate, hf_version)){
+                  LOG_PRINT_L2("Failed to get conversition rate for transaction " << tx.hash << " total supply will not account properly for fees in XHV");
+                } else {
+                    boost::multiprecision::uint128_t tx_fee_128 = tx.rct_signatures.txnFee; // Fee stored in XHV
+                    tx_fee_128 *= conversion_rate;
+                    tx_fee_128 /= COIN;
+                    boost::multiprecision::uint128_t conversion_fee_128 = tx.amount_burnt; // Fee stored in XHV
+                    conversion_fee_128 *= 3;
+                    conversion_fee_128 /= 200;
+                    fee_in_strSource += tx_fee_128.convert_to<uint64_t>();
+                    fee_in_strSource += conversion_fee_128.convert_to<uint64_t>();
+                    cs.amount_burnt+=fee_in_strSource;
+                    MDEBUG(print_money(tx.amount_burnt) << " " << print_money(tx_fee_128.convert_to<uint64_t>()) << " " <<  print_money(conversion_fee_128.convert_to<uint64_t>()));
+                }
+              }
+              
+              cs.amount_minted = tx.amount_minted;
+              MDEBUG("height: "<< height <<" Burnt: << " << print_money(cs.amount_burnt) << strSource << " minted " << print_money(cs.amount_minted) << strDest << " and " << print_money(fee_in_XHV) << "XHV");
+              total_new_supply[cs.source_currency_type] -= cs.amount_burnt;
+              total_new_supply[cs.dest_currency_type] += cs.amount_minted;
+              total_new_supply[XHV_currency_type_id] += fee_in_XHV;
+            }
           }
         
       }

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -31,6 +31,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/circular_buffer.hpp>
+#include <cstdint>
 #include <memory>  // std::unique_ptr
 #include <cstring>  // memcpy
 
@@ -1111,6 +1112,7 @@ uint64_t BlockchainLMDB::add_transaction_data(const crypto::hash& blk_hash, cons
   bool is_burn_tx = (strSource == strDest) && tx.amount_burnt > 0;
   // NEAC : check for presence of offshore TX to see if we need to update circulating supply information
   // Tay8NWWFKpz9JT4NXU0w: Also burn transactions affect the supply
+  uint64_t fee_in_XHV=0;
   if ((tx.version >= OFFSHORE_TRANSACTION_VERSION) && (is_mint_and_burn_tx || is_burn_tx)) {  
     // Offshore TX - update our records
     circ_supply cs;
@@ -1119,6 +1121,10 @@ uint64_t BlockchainLMDB::add_transaction_data(const crypto::hash& blk_hash, cons
     cs.source_currency_type = std::find(offshore::ASSET_TYPES.begin(), offshore::ASSET_TYPES.end(), strSource) - offshore::ASSET_TYPES.begin();
     cs.dest_currency_type = std::find(offshore::ASSET_TYPES.begin(), offshore::ASSET_TYPES.end(), strDest) - offshore::ASSET_TYPES.begin();
     cs.amount_burnt = tx.amount_burnt;
+    if(m_height>=SUPPLY_AUDIT_BLOCK_HEIGHT && is_mint_and_burn_tx){ //Fees are in XHV, so have to be removed from the supply. This is actually a bug from earlier, but only discovered during the supply audit.
+      fee_in_XHV=tx.rct_signatures.txnFee + tx.rct_signatures.txnOffshoreFee;
+      cs.amount_burnt+=fee_in_XHV;
+    }
     cs.amount_minted = tx.amount_minted;
     MDB_val_set(val_circ_supply, cs);
     result = mdb_cursor_put(m_cur_circ_supply, &val_tx_id, &val_circ_supply, MDB_APPEND);
@@ -1139,11 +1145,20 @@ uint64_t BlockchainLMDB::add_transaction_data(const crypto::hash& blk_hash, cons
     }
     write_circulating_supply_data(m_cur_circ_supply_tally, source_idx, final_source_tally);
 
+
     // Get the current tally value for the dest currency type
     MDB_val_copy<uint64_t> dest_idx(cs.dest_currency_type);
     boost::multiprecision::int128_t dest_tally = read_circulating_supply_data(m_cur_circ_supply_tally, dest_idx);
     boost::multiprecision::int128_t final_dest_tally = dest_tally + cs.amount_minted;
     write_circulating_supply_data(m_cur_circ_supply_tally, dest_idx, final_dest_tally);
+
+    if(fee_in_XHV>0){
+      uint64_t source_idx_XHV = std::find(offshore::ASSET_TYPES.begin(), offshore::ASSET_TYPES.end(), "XHV") - offshore::ASSET_TYPES.begin();
+      MDB_val_copy<uint64_t> dest_idx(source_idx_XHV);
+      boost::multiprecision::int128_t dest_tally_XHV = read_circulating_supply_data(m_cur_circ_supply_tally, dest_idx);
+      boost::multiprecision::int128_t final_dest_tally_XHV = dest_tally_XHV + fee_in_XHV;
+      write_circulating_supply_data(m_cur_circ_supply_tally, dest_idx, final_dest_tally_XHV);
+    }
 
     LOG_PRINT_L2("tx ID " << tx_id << "\nSource tally before burn =" << source_tally.str() << "\nSource tally after burn =" << final_source_tally.str() <<
                  "\nDest tally before mint =" << dest_tally.str() << "\nDest tally after mint =" << final_dest_tally.str());
@@ -1232,6 +1247,11 @@ void BlockchainLMDB::remove_transaction_data(const crypto::hash& tx_hash, const 
     cs.tx_hash = tx_hash;
     cs.pricing_record_height = tx.pricing_record_height;
     cs.amount_burnt = tx.amount_burnt;
+    uint64_t fee_in_XHV = 0;
+    if(m_height>=SUPPLY_AUDIT_BLOCK_HEIGHT && is_mint_and_burn_tx){ //Fees are in XHV, so have to be removed from the supply. This is actually a bug from earlier, but only discovered during the supply audit.
+      fee_in_XHV=tx.rct_signatures.txnFee + tx.rct_signatures.txnOffshoreFee;
+      cs.amount_burnt+=fee_in_XHV;
+    }
     cs.amount_minted = tx.amount_minted;
     cs.source_currency_type = std::find(offshore::ASSET_TYPES.begin(), offshore::ASSET_TYPES.end(), strSource) - offshore::ASSET_TYPES.begin();
     cs.dest_currency_type = std::find(offshore::ASSET_TYPES.begin(), offshore::ASSET_TYPES.end(), strDest) - offshore::ASSET_TYPES.begin();
@@ -1253,6 +1273,19 @@ void BlockchainLMDB::remove_transaction_data(const crypto::hash& tx_hash, const 
       final_dest_tally = 0;
     }
     write_circulating_supply_data(m_cur_circ_supply_tally, dest_idx, final_dest_tally);
+
+    if(fee_in_XHV>0){
+      uint64_t source_idx_XHV = std::find(offshore::ASSET_TYPES.begin(), offshore::ASSET_TYPES.end(), "XHV") - offshore::ASSET_TYPES.begin();
+      MDB_val_copy<uint64_t> dest_idx(source_idx_XHV);
+      boost::multiprecision::int128_t dest_tally_XHV = read_circulating_supply_data(m_cur_circ_supply_tally, dest_idx);
+      boost::multiprecision::int128_t final_dest_tally_XHV = dest_tally_XHV - fee_in_XHV;
+      if (coinbase+final_dest_tally_XHV<0){
+        LOG_ERROR(__func__ << " : mint/burn underflow detected for XHV: correcting supply tally by " << final_dest_tally_XHV);
+        final_dest_tally_XHV = 0;
+      }
+      write_circulating_supply_data(m_cur_circ_supply_tally, dest_idx, final_dest_tally_XHV);
+    }
+
 
     // Update the circ_supply table
     if ((result = mdb_cursor_get(m_cur_circ_supply, &val_tx_id, NULL, MDB_SET)))

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -82,6 +82,13 @@
 #define HF23_SHORING_LOCK_BLOCKS_TESTNET                10      // 20 minute unlock time - FOR TESTING ONLY
 #define HF23_XASSET_LOCK_BLOCKS_TESTNET                 20      // 40 minute unlock time - FOR TESTING ONLY
 
+// HF23 Unlock times
+#define HF27_SHORING_LOCK_BLOCKS                        10     // 20 minute unlock time
+#define HF27_XASSET_LOCK_BLOCKS                         720    // 1 day unlock time
+#define HF27_SHORING_LOCK_BLOCKS_TESTNET                10      // 20 minute unlock time - FOR TESTING ONLY
+#define HF27_XASSET_LOCK_BLOCKS_TESTNET                 20      // 40 minute unlock time - FOR TESTING ONLY
+
+
 #define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW               60
 
 // MONEY_SUPPLY - total number coins to be generated
@@ -271,7 +278,7 @@
 
 
 #define HF_VERSION_SUPPLY_AUDIT_END             26
-#define HF_VERSION_VBS_REMOVAL                  27
+#define HF_VERSION_VBS_DISABLING                  27
 
 
 #define STAGENET_VERSION                        0x0e

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -647,6 +647,7 @@ namespace cryptonote
     bool check_unlock_time(const uint64_t output_unlock_time, const uint64_t tx_height, const cryptonote::transaction_type tx_type, const std::string& output_asset_type, const bool is_collateral, const bool is_collateral_change, const uint8_t hf_version) const;
     bool check_unlock_time_21(const uint64_t output_unlock_time, const uint64_t tx_height, const cryptonote::transaction_type tx_type, const std::string& output_asset_type, const bool is_collateral, const bool is_collateral_change) const;
     bool check_unlock_time_23(const uint64_t output_unlock_time, const uint64_t tx_height, const cryptonote::transaction_type tx_type, const std::string& output_asset_type, const bool is_collateral, const bool is_collateral_change) const;
+    bool check_unlock_time_27(const uint64_t output_unlock_time, const uint64_t tx_height, const cryptonote::transaction_type tx_type, const std::string& output_asset_type, const bool is_collateral, const bool is_collateral_change) const;
     
     /**
      * @brief get fee quantization mask

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -988,7 +988,7 @@ namespace cryptonote
     // Calculate the market cap ratio
     cpp_bin_float_quad ratio_mcap_128 = mcap_xassets.convert_to<cpp_bin_float_quad>() / mcap_xhv.convert_to<cpp_bin_float_quad>();
     double ratio_mcap = ratio_mcap_128.convert_to<double>();
-    if (hf_version >= HF_VERSION_VBS_REMOVAL) {
+    if (hf_version >= HF_VERSION_VBS_DISABLING) {
       // No collateral needed
       collateral = 0;
       // Done - return to caller

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -356,7 +356,6 @@ namespace cryptonote
           // Miner component of the xAsset TX fee
           r = crypto::derive_public_key(derivation, idx, miner_address.m_spend_public_key, out_eph_public_key);
           CHECK_AND_ASSERT_MES(r, false, "while creating outs: failed to derive_public_key(" << derivation << ", " << idx << ", "<< miner_address.m_spend_public_key << ")");
-          idx++;
           crypto::view_tag view_tag;
 
           if (hard_fork_version >= HF_VERSION_VIEW_TAGS) {
@@ -386,6 +385,7 @@ namespace cryptonote
             out_miner.target = tk_miner;
             tx.vout.push_back(out_miner);
           }
+          idx++;
 
           crypto::public_key out_eph_public_key_xasset = AUTO_VAL_INIT(out_eph_public_key_xasset);
           if (!get_deterministic_output_key(governance_wallet_address.address, gov_key, idx /* n'th output in miner tx */, out_eph_public_key_xasset, view_tag))


### PR DESCRIPTION
Issues fixed:
- Supply recalculation
- Miner fees view tag
- audit_subaccount - incorrect derivation of is_subaccount

New features:
- Warning added in the CLI if there are funds to undergo audit
- sweep_all now fails when mixed outputs are spend with an error message suggesting audit
- Lock times for on/offshores and xasset changes adapted
 