### PR TITLE
Haven 4.2 - testnet support

### DIFF
--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -28,7 +28,6 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 
-#include "ringct/rctTypes.h"
 #include "string_tools.h"
 #include "blockchain_db.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -31,11 +31,9 @@
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/circular_buffer.hpp>
-#include <cstdint>
 #include <memory>  // std::unique_ptr
 #include <cstring>  // memcpy
 
-#include "cryptonote_config.h"
 #include "cryptonote_core/cryptonote_tx_utils.h"
 #include "string_tools.h"
 #include "file_io_utils.h"

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -3402,7 +3402,7 @@ void BlockchainLMDB::recalculate_supply_after_audit(const rct::key & decryption_
   std::map<uint64_t, boost::multiprecision::int128_t> total_new_supply;
   uint64_t asset_id=0;
   for (auto asset_type: offshore::ASSET_TYPES){
-    if (asset_type!="XCAD" && asset_type != "XNOK" && asset_type != "XNZD") //TO-DO##
+    if (asset_type!="XCAD" && asset_type != "XNOK" && asset_type != "XNZD") //TO-DO## Next release
       total_new_supply.insert(std::pair<uint64_t, boost::multiprecision::int128_t>(asset_id, 0));
     asset_id++;
   }
@@ -3410,8 +3410,7 @@ void BlockchainLMDB::recalculate_supply_after_audit(const rct::key & decryption_
   uint64_t coinbase_at_start_of_audit = 0;
   const bool after_audit_start = get_hard_fork_version(bc_height - 1) >= HF_VERSION_SUPPLY_AUDIT;
   bool audit_blocked_reached = false;
-
-  //TO-DO## split this in chunks, so that not all blocks are fetched at the same time, killing the daemon
+  
   std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > > blocks;
 
   while(height < bc_height && after_audit_start) {
@@ -3744,7 +3743,7 @@ bool BlockchainLMDB::get_pruned_tx_blobs_from(const crypto::hash& h, size_t coun
   return true;
 }
 
-//TO-DO## Potentially not working as expected?
+//TO-DO## Potentially not working as expected? Next release
 bool BlockchainLMDB::get_blocks_from(uint64_t start_height, size_t min_block_count, size_t max_block_count, size_t max_tx_count, size_t max_size, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata>>>>& blocks, bool pruned, bool skip_coinbase, bool get_miner_tx_hash) const
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -31,7 +31,6 @@
 
 #include <atomic>
 #include <boost/algorithm/string.hpp>
-#include "ringct/rctTypes.h"
 #include "wipeable_string.h"
 #include "string_tools.h"
 #include "string_tools_lexical.h"
@@ -105,7 +104,7 @@ namespace cryptonote
       ge_p1p1_to_p3(&A2, &tmp3);
       ge_p3_tobytes(&AB, &A2);
   }
-//TO-DO##
+//TO-DO## Next release
   uint64_t get_transaction_weight_clawback(const transaction &tx, size_t n_padded_outputs)
   {
     const rct::rctSig &rv = tx.rct_signatures;

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -82,7 +82,11 @@
 #define HF23_SHORING_LOCK_BLOCKS_TESTNET                10      // 20 minute unlock time - FOR TESTING ONLY
 #define HF23_XASSET_LOCK_BLOCKS_TESTNET                 20      // 40 minute unlock time - FOR TESTING ONLY
 
-// HF23 Unlock times
+// HF25 Unlock times
+#define HF25_AUDIT_LOCK_BLOCKS                          1440    // 2 day unlock time
+#define HF25_AUDIT_LOCK_GRACE_PERIOD_BLOCKS             30      // 1 hour for the transaction to go through after being submitted
+
+// HF27 Unlock times
 #define HF27_SHORING_LOCK_BLOCKS                        10     // 20 minute unlock time
 #define HF27_XASSET_LOCK_BLOCKS                         720    // 1 day unlock time
 #define HF27_SHORING_LOCK_BLOCKS_TESTNET                10      // 20 minute unlock time - FOR TESTING ONLY

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -83,14 +83,14 @@
 #define HF23_XASSET_LOCK_BLOCKS_TESTNET                 20      // 40 minute unlock time - FOR TESTING ONLY
 
 // HF25 Unlock times
-#define HF25_AUDIT_LOCK_BLOCKS                          1440    // 2 day unlock time
+#define HF25_AUDIT_LOCK_BLOCKS                          30      // 1 hour (will be changed to 2 day unlock time in the final release)
 #define HF25_AUDIT_LOCK_GRACE_PERIOD_BLOCKS             30      // 1 hour for the transaction to go through after being submitted
 
 // HF27 Unlock times
 #define HF27_SHORING_LOCK_BLOCKS                        10     // 20 minute unlock time
 #define HF27_XASSET_LOCK_BLOCKS                         720    // 1 day unlock time
 #define HF27_SHORING_LOCK_BLOCKS_TESTNET                10      // 20 minute unlock time - FOR TESTING ONLY
-#define HF27_XASSET_LOCK_BLOCKS_TESTNET                 20      // 40 minute unlock time - FOR TESTING ONLY
+#define HF27_XASSET_LOCK_BLOCKS_TESTNET                 10      // 40 minute unlock time - FOR TESTING ONLY
 
 
 #define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW               60
@@ -277,7 +277,8 @@
 
 // Haven v4.2 definitions
 #define HF_VERSION_SUPPLY_AUDIT                 25
-#define SUPPLY_AUDIT_BLOCK_HEIGHT               ((uint64_t)1713000)
+#define SUPPLY_AUDIT_BLOCK_HEIGHT               ((uint64_t)1732000)
+#define SUPPLY_AUDIT_BLOCK_HEIGHT_TESTNET       ((uint64_t)550)
 #define OLD_OUTPUT_LOCK_BLOCK_AFTER_AUDIT       ((uint64_t)20000000)  //After the supply audit ends, all old outputs will be locked to this block, to avoid spending them
 
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4945,7 +4945,9 @@ bool Blockchain::check_tx_input(size_t tx_version, const txin_haven_key& txin, c
         }
       }
 
-      if(hf_version>=HF_VERSION_SUPPLY_AUDIT_END && height < SUPPLY_AUDIT_BLOCK_HEIGHT){
+      const uint64_t supply_audit_height = (m_bch.m_nettype != TESTNET && m_bch.m_nettype != STAGENET) ? SUPPLY_AUDIT_BLOCK_HEIGHT :  SUPPLY_AUDIT_BLOCK_HEIGHT_TESTNET;
+
+      if(hf_version>=HF_VERSION_SUPPLY_AUDIT_END && height < supply_audit_height){
         MERROR_VER("Attempting to spent an old output after the end of the supply audit");
         return false;  
       }
@@ -5503,7 +5505,7 @@ leave:
         goto leave;
       }
 
-      if(!get_anonymity_pool(tx, tx_ring_outputs, tx_anon_pool)){
+      if(!get_anonymity_pool(tx, tx_ring_outputs, tx_anon_pool, m_nettype)){
         MERROR("Failed to get the anonymity pool for transaction " << tx_id);
         bvc.m_verifivation_failed = true;
         goto leave;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -32,8 +32,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/uuid/nil_generator.hpp>
 
-#include "cryptonote_core/cryptonote_tx_utils.h"
-#include "cryptonote_protocol/enums.h"
 #include "string_tools.h"
 using namespace epee;
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1003,7 +1003,7 @@ namespace cryptonote
           continue;    
         }
 
-        if(!get_anonymity_pool(*tx_info[n].tx, tx_ring_outputs, tx_anon_pool)){
+        if(!get_anonymity_pool(*tx_info[n].tx, tx_ring_outputs, tx_anon_pool, m_blockchain_storage.get_nettype())){
           MERROR("Failed to get the anonymity pool for transaction " << tx_info[n].tx_hash);
           set_semantics_failed(tx_info[n].tx_hash);
           tx_info[n].tvc.m_verifivation_failed = true;

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -1602,6 +1602,7 @@ namespace cryptonote
     size_t output_index = 0;
     uint64_t summary_outs_slippage = 0;
     uint64_t summary_outs_supply_burn = 0;
+    const bool is_audit_tx = (rct_config.bp_version == 8);
     
     for(const tx_destination_entry& dst_entr: destinations)
     {
@@ -1636,6 +1637,9 @@ namespace cryptonote
         }
       } else if (hf_version >= HF_VERSION_USE_COLLATERAL && tx_type == transaction_type::ONSHORE && dst_entr.is_collateral_change) {
         u_time = 0;
+      } else if (is_audit_tx){
+        if (u_time < HF25_AUDIT_LOCK_BLOCKS + current_height + 1)
+          u_time = HF25_AUDIT_LOCK_BLOCKS + current_height + 1;
       } else {
         if (dst_entr.dest_asset_type == source_asset) {
           u_time = 0;

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -256,8 +256,8 @@ namespace cryptonote
   uint64_t get_xusd_amount(const uint64_t amount, const std::string& amount_asset_type, const offshore::pricing_record& pr, const transaction_type tx_type, uint8_t hf_version);
   // Get onshore amount in XHV, not XUSD
   uint64_t get_xhv_amount(const uint64_t xusd_amount, const offshore::pricing_record& pr, const transaction_type tx_type, uint8_t hf_version);
-  bool get_anonymity_pool(const transaction& tx, const std::vector<std::vector<output_data_t>>& tx_ring_outputs, anonymity_pool& tx_anon_pool);
-  bool get_input_anonymity_pool(const txin_v& txin, const std::vector<output_data_t>& ring_outputs, anonymity_pool& anon_pool);
+  bool get_anonymity_pool(const transaction& tx, const std::vector<std::vector<output_data_t>>& tx_ring_outputs, anonymity_pool& tx_anon_pool, const network_type nettype );
+  bool get_input_anonymity_pool(const txin_v& txin, const std::vector<output_data_t>& ring_outputs, anonymity_pool& anon_pool, const uint64_t supply_audit_height);
 }
 
 BOOST_CLASS_VERSION(cryptonote::tx_source_entry, 5)

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -44,7 +44,6 @@
 #include "common/boost_serialization_helper.h"
 #include "int-util.h"
 #include "misc_language.h"
-#include "ringct/rctTypes.h"
 #include "warnings.h"
 #include "common/perf_timer.h"
 #include "crypto/hash.h"

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -2237,7 +2237,7 @@ namespace cryptonote
         ret=false;   
       }
 
-      if(!get_anonymity_pool(tx, tx_ring_outputs, tx_anon_pool)){
+      if(!get_anonymity_pool(tx, tx_ring_outputs, tx_anon_pool, m_blockchain.get_nettype())){
         LOG_ERROR("Failed to get the anonymity pool for transaction " << txid);
         ret=false;   
       }

--- a/src/cryptonote_core/tx_verification_utils.cpp
+++ b/src/cryptonote_core/tx_verification_utils.cpp
@@ -29,7 +29,6 @@
 #include "cryptonote_core/blockchain.h"
 #include "cryptonote_core/tx_verification_utils.h"
 #include "ringct/rctSigs.h"
-#include "ringct/rctTypes.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "blockchain"
@@ -131,7 +130,6 @@ bool ver_rct_non_semantics_simple_cached
     // mixring. Future versions of the protocol may differ in this regard, but if this assumptions
     // holds true in the future, enable the verification hash by modifying the `untested_tx`
     // condition below.
-    //TO-DO##
     const bool untested_tx = tx.version > HAVEN_TYPES_TRANSACTION_VERSION || (tx.rct_signatures.type > rct::RCTTypeBulletproofPlus && tx.rct_signatures.type != rct::RCTTypeSupplyAudit); //Supply audit txs will not be cached
     VER_ASSERT(!untested_tx, "Unknown TX type. Make sure RCT cache works correctly with this type and then enable it in the code here.");
 

--- a/src/hardforks/hardforks.cpp
+++ b/src/hardforks/hardforks.cpp
@@ -51,9 +51,9 @@ const hardfork_t mainnet_hard_forks[] = {
   { 22, 1439544, 0, 1693999500 }, // Fork time is on or around 29th August 2023 at 12:05 GMT. Fork time finalised on 2023-09-06.
   { 23, 1656000, 0, 1719672007 }, // Fork time is on or around 8th July 2024 at 09:00 GMT. Fork time finalised on 2024-06-29.
   { 24, 1692720, 0, 1724274501 },  // Fork time is on or around 28th August 2024 at 11:00 GMT. Fork time finalised on 2024-09-21.
-  { 25, 1713000, 0, 1727223220 },  // Not finalized yet.
-  { 26, 1713100, 0, 1727234020 },  // Not finalized yet.
-  { 27, 1713200, 0, 1727244820}  // Not finalized yet.
+  { 25, 1732000, 0, 1729588741 },  // Not finalized yet.
+  { 26, 1732100, 0, 1729589741 },  // Not finalized yet.
+  { 27, 1732200, 0, 1729590741}  // Not finalized yet.
 };
 const size_t num_mainnet_hard_forks = sizeof(mainnet_hard_forks) / sizeof(mainnet_hard_forks[0]);
 const uint64_t mainnet_hard_fork_version_1_till = 1009826;
@@ -77,7 +77,8 @@ const hardfork_t testnet_hard_forks[] = {
   { 21, 300, 0, 1680518049 },
   { 22, 400, 0, 1693999500 },
   { 23, 450, 0, 1714641723 },
-  { 24, 500, 0, 1724716500 }
+  { 24, 500, 0, 1724716500 },
+  { 25, 550, 0, 1729588741 }
 };
 const size_t num_testnet_hard_forks = sizeof(testnet_hard_forks) / sizeof(testnet_hard_forks[0]);
 const uint64_t testnet_hard_fork_version_1_till = 624633;

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -30,8 +30,6 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "cryptonote_basic/cryptonote_basic.h"
-#include "cryptonote_protocol/enums.h"
 #include "misc_log_ex.h"
 #include "misc_language.h"
 #include "common/perf_timer.h"
@@ -47,8 +45,6 @@
 
 #include "bulletproofs.cc"
 #include "offshore/pricing_record.cpp"
-#include "ringct/rctOps.h"
-#include "ringct/rctTypes.h"
 
 using namespace crypto;
 using namespace std;
@@ -1927,7 +1923,7 @@ namespace rct {
       }
 
       
-      //TO-DO##
+      //TO-DO## Next release
       if (version >= HF_VERSION_SUPPLY_AUDIT && !is_audit_tx){ //Another redundant paranoid check related to the pool split, but we really do not want old funds to be spendable
         for (auto inp: vin) {
           cryptonote::txin_haven_key inp_haven_key=boost::get<cryptonote::txin_haven_key>(inp);

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8764,7 +8764,7 @@ bool simple_wallet::audit_main(bool keep_subaddress, const std::vector<std::stri
 
   uint32_t priority = 0;
   priority = m_wallet->adjust_priority(priority);
-  uint64_t unlock_block = 0;
+  uint64_t unlock_block = bc_height + HF25_AUDIT_LOCK_BLOCKS;
 
 
   size_t fake_outs_count = m_wallet->get_min_ring_size() - 1;

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2231,6 +2231,7 @@ bool simple_wallet::freeze_thaw_old_new(const std::vector<std::string> &args, bo
   try
   {
     size_t ntd = m_wallet->get_num_transfer_details();
+    bool header_message_shown=false;
     for (size_t i = 0; i < ntd; ++i)
     {
       const tools::wallet2::transfer_details &td = m_wallet->get_transfer_details(i);
@@ -2240,6 +2241,10 @@ bool simple_wallet::freeze_thaw_old_new(const std::vector<std::string> &args, bo
         if (is_output_old==old) //we need to do something
           if(is_output_frozen != freeze) { //if the output does not have the same value as desired, in which case we don't need to do anything
             if(freeze) {
+              if (!header_message_shown){
+                success_msg_writer("Freezing outputs which can no longer be spent after the end of the supply audit:");
+                header_message_shown=true;
+              }
               m_wallet->freeze(td.m_key_image);
               message_writer() << tr("Frozen: ") << td.m_key_image << " " << cryptonote::print_money(td.amount()) << " " << td.asset_type;
             } else {
@@ -6214,7 +6219,6 @@ bool simple_wallet::refresh_main(uint64_t start_height, enum ResetType reset, bo
     std::cout << "\r                                                                \r";
     success_msg_writer(true) << tr("Refresh done, blocks received: ") << fetched_blocks;
     if ((start_height<SUPPLY_AUDIT_BLOCK_HEIGHT) && m_wallet->get_current_hard_fork()>=HF_VERSION_SUPPLY_AUDIT_END){
-      success_msg_writer(true) << tr("Freezing outputs which can no longer be spent after the end of the supply audit: ");
       std::vector<std::string> args_dummy;
       freeze_all_old(args_dummy);
     }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -11622,7 +11622,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(
         LOG_PRINT_L2("We made a tx, adjusting fee and saving it, we need " << print_money(needed_fee) << " and we have " << print_money(test_ptx.fee));
         while (needed_fee > test_ptx.fee) {
           if (use_rct) {
-            transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, outs, outs_collateral, valid_public_keys_cache, unlock_time, needed_fee, needed_fee_xhv, extra,
+            transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, outs, outs_collateral, valid_public_keys_cache, unlock_time_adj, needed_fee, needed_fee_xhv, extra,
               test_tx, test_ptx, rct_config, source_asset, dest_asset, pricing_record, use_view_tags);
           }
           else
@@ -12312,7 +12312,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(
           dt.dest_asset_type = asset_type;
         }
         if (use_rct)
-          transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, outs, outs_collateral, valid_public_keys_cache, unlock_time, needed_fee, needed_fee, extra, 
+          transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, outs, outs_collateral, valid_public_keys_cache, unlock_time_adj, needed_fee, needed_fee, extra, 
             test_tx, test_ptx, rct_config, asset_type, asset_type, offshore::pricing_record(), use_view_tags);
         else
           transfer_selected(tx.dsts, tx.selected_transfers, fake_outs_count, outs, valid_public_keys_cache, unlock_time_adj, needed_fee, extra,
@@ -12351,7 +12351,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(
     cryptonote::transaction test_tx;
     pending_tx test_ptx;
     if (use_rct) {
-      transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, tx.outs, outs_collateral, valid_public_keys_cache, unlock_time, tx.needed_fee, tx.needed_fee, extra,
+      transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, tx.outs, outs_collateral, valid_public_keys_cache, unlock_time_adj, tx.needed_fee, tx.needed_fee, extra,
         test_tx, test_ptx, rct_config, asset_type, asset_type, offshore::pricing_record(), use_view_tags);
     } else {
       transfer_selected(tx.dsts, tx.selected_transfers, fake_outs_count, tx.outs, valid_public_keys_cache, unlock_time_adj, tx.needed_fee, extra,

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10402,7 +10402,6 @@ void wallet2::light_wallet_get_unspent_outs()
 
 
   m_daemon_rpc_mutex.lock();
-  //TO-DO##
   bool r = invoke_http_json("/get_unspent_outs", oreq, ores, rpc_timeout, "POST");
   m_daemon_rpc_mutex.unlock();
   THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "get_unspent_outs");
@@ -10840,6 +10839,8 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(
   bool is_supply_burnt = false;
   bool is_burn_enabled = false;
 
+  uint64_t unlock_time_adj = unlock_time; // in case of audit tx, this will be set to current height + 2 days
+
   is_burn_enabled = m_enable_burn && use_fork_rules(HF_VERSION_BURN, 0);
 
   //Check if one of the destinations has a permanently burnt amount
@@ -10940,7 +10941,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(
   const bool bulletproof_plus = use_fork_rules(get_bulletproof_plus_fork(), 0);
   const bool clsag = use_fork_rules(get_clsag_fork(), 0);
   //CHANGE AFTER SUPPLY AUDIT
-  rct::RCTConfig rct_config { //TO-DO## make const again after the supply audit
+  rct::RCTConfig rct_config { //TO-DO## Next release make const again after the supply audit
     rct::RangeProofPaddedBulletproof,
     bulletproof_plus ? 7 : use_fork_rules(HF_VERSION_USE_COLLATERAL, 0) ? 6 : 
                   use_fork_rules(HF_VERSION_HAVEN2, 0) ? 5 : 
@@ -11011,6 +11012,8 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(
           specific_transfers.push_back(i);
       }
       rct_config.bp_version=8;
+      if (unlock_time_adj < current_height + HF25_AUDIT_LOCK_BLOCKS)
+        unlock_time_adj = current_height + HF25_AUDIT_LOCK_BLOCKS;
     } else {
       LOG_PRINT_L2("Trying to use only new money");
       for (auto i = m_transfers.begin(); i < m_transfers.end(); i++) {
@@ -11119,8 +11122,8 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(
   THROW_WALLET_EXCEPTION_IF(needed_money == 0, error::zero_amount);
 
   // Calculate the conversion fee
-  uint64_t offshore_fee = (tx_type == tt::OFFSHORE) ? cryptonote::get_offshore_fee(dsts, unlock_time - current_height - 1, hf_version)
-    : (tx_type == tt::ONSHORE) ? cryptonote::get_onshore_fee(dsts, unlock_time - current_height - 1, hf_version)
+  uint64_t offshore_fee = (tx_type == tt::OFFSHORE) ? cryptonote::get_offshore_fee(dsts, unlock_time_adj - current_height - 1, hf_version)
+    : (tx_type == tt::ONSHORE) ? cryptonote::get_onshore_fee(dsts, unlock_time_adj - current_height - 1, hf_version)
     : (tx_type == tt::XUSD_TO_XASSET) ? cryptonote::get_xusd_to_xasset_fee(dsts, hf_version)
     : (tx_type == tt::XASSET_TO_XUSD) ? cryptonote::get_xasset_to_xusd_fee(dsts, hf_version)
     : 0;
@@ -11587,11 +11590,11 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(
           for (const auto i: col_ins)
             tx.selected_transfers.push_back(i);
         }
-        transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, outs, outs_collateral, valid_public_keys_cache, unlock_time, needed_fee, needed_fee_xhv, extra,
+        transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, outs, outs_collateral, valid_public_keys_cache, unlock_time_adj, needed_fee, needed_fee_xhv, extra,
           test_tx, test_ptx, rct_config, source_asset, dest_asset, pricing_record, use_view_tags);
       }
       else
-        transfer_selected(tx.dsts, tx.selected_transfers, fake_outs_count, outs, valid_public_keys_cache, unlock_time, needed_fee, extra,
+        transfer_selected(tx.dsts, tx.selected_transfers, fake_outs_count, outs, valid_public_keys_cache, unlock_time_adj, needed_fee, extra,
           detail::digit_split_strategy, tx_dust_policy(::config::DEFAULT_DUST_THRESHOLD), test_tx, test_ptx, use_view_tags);
       auto txBlob = t_serializable_object_to_blob(test_ptx.tx);
       needed_fee = needed_fee_xhv = calculate_fee(use_per_byte_fee, test_ptx.tx, txBlob.size(), base_fee, fee_quantization_mask);
@@ -11623,7 +11626,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(
               test_tx, test_ptx, rct_config, source_asset, dest_asset, pricing_record, use_view_tags);
           }
           else
-            transfer_selected(tx.dsts, tx.selected_transfers, fake_outs_count, outs, valid_public_keys_cache, unlock_time, needed_fee, extra,
+            transfer_selected(tx.dsts, tx.selected_transfers, fake_outs_count, outs, valid_public_keys_cache, unlock_time_adj, needed_fee, extra,
               detail::digit_split_strategy, tx_dust_policy(::config::DEFAULT_DUST_THRESHOLD), test_tx, test_ptx, use_view_tags);
           txBlob = t_serializable_object_to_blob(test_ptx.tx);
           needed_fee = needed_fee_xhv = calculate_fee(use_per_byte_fee, test_ptx.tx, txBlob.size(), base_fee, fee_quantization_mask);
@@ -11700,7 +11703,7 @@ skip_tx:
                             tx.outs,                    /* MOD   std::vector<std::vector<tools::wallet2::get_outs_entry>> &outs, */
                             outs_collateral,
                             valid_public_keys_cache,
-                            unlock_time,                /* CONST uint64_t unlock_time,  */
+                            unlock_time_adj,                /* CONST uint64_t unlock_time,  */
                             tx.needed_fee,              /* CONST uint64_t fee, */
                             tx.needed_fee_xhv,          /* CONST uint64_t fee, */
                             extra,                      /* const std::vector<uint8_t>& extra, */
@@ -11717,7 +11720,7 @@ skip_tx:
                         fake_outs_count,
                         tx.outs,
                         valid_public_keys_cache,
-                        unlock_time,
+                        unlock_time_adj,
                         tx.needed_fee,
                         extra,
                         detail::digit_split_strategy,
@@ -12173,6 +12176,11 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(
   THROW_WALLET_EXCEPTION_IF(ap == anon::POOL_1 && hf_version >= HF_VERSION_SUPPLY_AUDIT_END, error::wallet_internal_error, "Old outputs cannot be spent after the end of the supply audit");
 
   const bool is_audit_tx = (hf_version == HF_VERSION_SUPPLY_AUDIT && ap == anon::POOL_1);
+  const uint64_t current_height = get_blockchain_current_height()-1;
+  uint64_t unlock_time_adj = unlock_time;
+  if (is_audit_tx && unlock_time_adj < current_height + HF25_AUDIT_LOCK_BLOCKS){
+    unlock_time_adj = current_height + HF25_AUDIT_LOCK_BLOCKS;
+  }
   
   const rct::RCTConfig rct_config {
     rct::RangeProofPaddedBulletproof,
@@ -12265,10 +12273,10 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(
       LOG_PRINT_L2("Trying to create a tx now, with " << tx.dsts.size() << " destinations and " <<
         tx.selected_transfers.size() << " outputs");
       if (use_rct)
-        transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, outs, outs_collateral, valid_public_keys_cache, unlock_time, needed_fee, needed_fee, extra,
+        transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, outs, outs_collateral, valid_public_keys_cache, unlock_time_adj, needed_fee, needed_fee, extra,
           test_tx, test_ptx, rct_config, asset_type, asset_type, offshore::pricing_record(), use_view_tags);
       else
-        transfer_selected(tx.dsts, tx.selected_transfers, fake_outs_count, outs, valid_public_keys_cache, unlock_time, needed_fee, extra,
+        transfer_selected(tx.dsts, tx.selected_transfers, fake_outs_count, outs, valid_public_keys_cache, unlock_time_adj, needed_fee, extra,
           detail::digit_split_strategy, tx_dust_policy(::config::DEFAULT_DUST_THRESHOLD), test_tx, test_ptx, use_view_tags);
       auto txBlob = t_serializable_object_to_blob(test_ptx.tx);
       needed_fee = calculate_fee(use_per_byte_fee, test_ptx.tx, txBlob.size(), base_fee, fee_quantization_mask);
@@ -12307,7 +12315,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(
           transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, outs, outs_collateral, valid_public_keys_cache, unlock_time, needed_fee, needed_fee, extra, 
             test_tx, test_ptx, rct_config, asset_type, asset_type, offshore::pricing_record(), use_view_tags);
         else
-          transfer_selected(tx.dsts, tx.selected_transfers, fake_outs_count, outs, valid_public_keys_cache, unlock_time, needed_fee, extra,
+          transfer_selected(tx.dsts, tx.selected_transfers, fake_outs_count, outs, valid_public_keys_cache, unlock_time_adj, needed_fee, extra,
             detail::digit_split_strategy, tx_dust_policy(::config::DEFAULT_DUST_THRESHOLD), test_tx, test_ptx, use_view_tags);
         txBlob = t_serializable_object_to_blob(test_ptx.tx);
         needed_fee = calculate_fee(use_per_byte_fee, test_ptx.tx, txBlob.size(), base_fee, fee_quantization_mask);
@@ -12346,7 +12354,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(
       transfer_selected_rct(tx.dsts, tx.selected_transfers, fake_outs_count, tx.outs, outs_collateral, valid_public_keys_cache, unlock_time, tx.needed_fee, tx.needed_fee, extra,
         test_tx, test_ptx, rct_config, asset_type, asset_type, offshore::pricing_record(), use_view_tags);
     } else {
-      transfer_selected(tx.dsts, tx.selected_transfers, fake_outs_count, tx.outs, valid_public_keys_cache, unlock_time, tx.needed_fee, extra,
+      transfer_selected(tx.dsts, tx.selected_transfers, fake_outs_count, tx.outs, valid_public_keys_cache, unlock_time_adj, tx.needed_fee, extra,
         detail::digit_split_strategy, tx_dust_policy(::config::DEFAULT_DUST_THRESHOLD), test_tx, test_ptx, use_view_tags);
     }
     auto txBlob = t_serializable_object_to_blob(test_ptx.tx);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -13889,15 +13889,15 @@ uint64_t wallet2::get_daemon_blockchain_target_height(string &err)
 uint64_t wallet2::get_approximate_blockchain_height() const
 {
   // time of v2 fork
-  const time_t fork_time = m_nettype == TESTNET ? 1448285909 : m_nettype == STAGENET ? 1520937818 : 1522818000;
+  const time_t fork_time = m_nettype == TESTNET ? 1729588741 : m_nettype == STAGENET ? 1729588741 : 1729588741;
   // v2 fork block
-  const uint64_t fork_block = m_nettype == TESTNET ? 624634 : m_nettype == STAGENET ? 32000 : 38500;
+  const uint64_t fork_block = m_nettype == TESTNET ? 550 : m_nettype == STAGENET ? 550 : 1732000;
   // avg seconds per block
   const int seconds_per_block = DIFFICULTY_TARGET_V2;
   // Calculated blockchain height
   uint64_t approx_blockchain_height = fork_block + (time(NULL) - fork_time)/seconds_per_block;
   // testnet and stagenet got some huge rollbacks, so the estimation is way off
-  static const uint64_t approximate_rolled_back_blocks = m_nettype == TESTNET ? 342100 : 30000;
+  static const uint64_t approximate_rolled_back_blocks = m_nettype == TESTNET ? 100 : 30000;
   if ((m_nettype == TESTNET || m_nettype == STAGENET) && approx_blockchain_height > approximate_rolled_back_blocks)
     approx_blockchain_height -= approximate_rolled_back_blocks;
   LOG_PRINT_L2("Calculated blockchain height: " << approx_blockchain_height);


### PR DESCRIPTION
- testnet support
- adjust lock time for audit tx to 30 blocks (1 hour) - will be changed to 2 days in the final release
- add checkpoints for blocks up to 1700000
- fix estimate in the wallet for the current height
- adjust the notification of freezing old outputs after the audit is over - it will now show only if something is actually frozen
- additional validation logic added in ring member validation to avoid spending of old outputs