### PR TITLE
Haven 4.2 - set audit transaction lock time to 2 days

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ all: release-all
 
 depends:
 	cd contrib/depends && $(MAKE) HOST=$(target) && cd ../.. && mkdir -p build/$(target)/release
-	cd build/$(target)/release && cmake -DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/contrib/depends/$(target)/share/toolchain.cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ../../.. && $(MAKE)
+	cd build/$(target)/release && cmake -DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/contrib/depends/$(target)/share/toolchain.cmake ../../.. && $(MAKE)
 
 cmake-debug:
 	mkdir -p $(builddir)/debug

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -83,7 +83,7 @@
 #define HF23_XASSET_LOCK_BLOCKS_TESTNET                 20      // 40 minute unlock time - FOR TESTING ONLY
 
 // HF25 Unlock times
-#define HF25_AUDIT_LOCK_BLOCKS                          30      // 1 hour (will be changed to 2 day unlock time in the final release)
+#define HF25_AUDIT_LOCK_BLOCKS                          1440      // 1 hour (will be changed to 2 day unlock time in the final release)
 #define HF25_AUDIT_LOCK_GRACE_PERIOD_BLOCKS             30      // 1 hour for the transaction to go through after being submitted
 
 // HF27 Unlock times

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -83,7 +83,7 @@
 #define HF23_XASSET_LOCK_BLOCKS_TESTNET                 20      // 40 minute unlock time - FOR TESTING ONLY
 
 // HF25 Unlock times
-#define HF25_AUDIT_LOCK_BLOCKS                          1440      // 1 hour (will be changed to 2 day unlock time in the final release)
+#define HF25_AUDIT_LOCK_BLOCKS                          1440      // 2 days unlock time
 #define HF25_AUDIT_LOCK_GRACE_PERIOD_BLOCKS             30      // 1 hour for the transaction to go through after being submitted
 
 // HF27 Unlock times


### PR DESCRIPTION
Changes:
- Fix bug where lock times of audit transactions were set to 1 hour instead of 2 days
- Revert temporary compiler settings introduced in a previous commit