### PR TITLE
enable anonymity pool checks before the start of the supply audit

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -278,6 +278,7 @@
 // Haven v4.2 definitions
 #define HF_VERSION_SUPPLY_AUDIT                 25
 #define SUPPLY_AUDIT_BLOCK_HEIGHT               ((uint64_t)1752270)
+#define SUPPLY_AUDIT_ANON_POOL_CHECK_HEIGHT     ((uint64_t)1748800) 
 #define SUPPLY_AUDIT_BLOCK_HEIGHT_TESTNET       ((uint64_t)410)
 #define OLD_OUTPUT_LOCK_BLOCK_AFTER_AUDIT       ((uint64_t)20000000)  //After the supply audit ends, all old outputs will be locked to this block, to avoid spending them
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -5460,7 +5460,7 @@ leave:
     
     // Get the TX anonymity pool
     anonymity_pool tx_anon_pool=anonymity_pool::UNSET;
-    if (hf_version>=HF_VERSION_BURN) {
+    if (hf_version>=HF_VERSION_BURN && blockchain_height >= SUPPLY_AUDIT_ANON_POOL_CHECK_HEIGHT) {
       std::vector<std::vector<output_data_t>> tx_ring_outputs;
       tx_ring_outputs.reserve(tx.vin.size());
       for (const txin_v& txin: tx.vin){
@@ -5516,8 +5516,13 @@ leave:
         bvc.m_verifivation_failed = true;
         goto leave;
       }
-    } else if (hf_version<HF_VERSION_BURN) {
+    } else if (hf_version < HF_VERSION_BURN || blockchain_height < SUPPLY_AUDIT_ANON_POOL_CHECK_HEIGHT) {
       tx_anon_pool=anonymity_pool::NOTAPPLICABLE;  
+    } else {
+      //This should not happen
+      MERROR_VER("Cannot validate anonymity pool for tx " << tx_id);
+      bvc.m_verifivation_failed = true;
+      goto leave;
     }
 
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -950,7 +950,7 @@ namespace cryptonote
       // Get the TX anonymity pool
       const uint64_t current_height = m_blockchain_storage.get_current_blockchain_height();
       anonymity_pool tx_anon_pool=anonymity_pool::UNSET;
-      if (hf_version>=HF_VERSION_BURN) {
+      if (hf_version >= HF_VERSION_BURN && current_height >= SUPPLY_AUDIT_ANON_POOL_CHECK_HEIGHT) {
         std::vector<std::vector<output_data_t>> tx_ring_outputs;
         tx_ring_outputs.reserve(tx_info[n].tx->vin.size());
         for (const txin_v& txin: tx_info[n].tx->vin){
@@ -1018,8 +1018,15 @@ namespace cryptonote
           tx_info[n].result = false;
           continue;
         }
-      } else if (hf_version<HF_VERSION_BURN){
+      } else if (hf_version<HF_VERSION_BURN || current_height < SUPPLY_AUDIT_ANON_POOL_CHECK_HEIGHT){
         tx_anon_pool=anonymity_pool::NOTAPPLICABLE;
+      } else {
+        //This should not happen
+        MERROR_VER("Failed to validate anonymity pool");
+        set_semantics_failed(tx_info[n].tx_hash);
+        tx_info[n].tvc.m_verifivation_failed = true;
+        tx_info[n].result = false;
+        continue;
       }
       tx_info[n].tvc.m_tx_anon_pool=tx_anon_pool;
 

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -1808,7 +1808,7 @@ namespace rct {
       // They require that the tx_anon_pool value is correct
       CHECK_AND_ASSERT_MES(tx_anon_pool != anon::UNSET, false, "Transaction anonymity pool type is not set.");
       CHECK_AND_ASSERT_MES(tx_anon_pool != anon::MIXED, false, "Transaction has a mixed anonymity pool which is not permited.");
-      CHECK_AND_ASSERT_MES(version < HF_VERSION_BURN || tx_anon_pool == anon::POOL_1 || tx_anon_pool == anon::POOL_2, false, "Transaction anonymity pool should be either Pool 1 or Pool 2 during the supply audit");
+      CHECK_AND_ASSERT_MES(version < HF_VERSION_SUPPLY_AUDIT || tx_anon_pool == anon::POOL_1 || tx_anon_pool == anon::POOL_2, false, "Transaction anonymity pool should be either Pool 1 or Pool 2 during the supply audit");
       CHECK_AND_ASSERT_MES(version < HF_VERSION_SUPPLY_AUDIT_END || tx_anon_pool == anon::POOL_2, false, "Transaction anonymity pool should be only Pool 2 after the end of the supply audit");
       //### Supply audit sanity checks #####
       //This check ensures old funds can't be spent after the audit is over.


### PR DESCRIPTION
The anonymity pool checks are now enabled at block 1748800