### PR TITLE
experimental wallet support above 18 million

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -93,7 +93,6 @@ namespace cryptonote {
       return true;
     }
 #endif
-    
     uint64_t base_reward = (MONEY_SUPPLY - already_generated_coins) >> emission_speed_factor;
     if (base_reward < FINAL_SUBSIDY_PER_MINUTE*target_minutes)
     {
@@ -109,6 +108,7 @@ namespace cryptonote {
 
     if (current_block_weight <= median_weight) {
       reward = base_reward;
+      reward = HAVEN_MAX_TX_VALUE;
       return true;
     }
 
@@ -132,6 +132,7 @@ namespace cryptonote {
     assert(reward_lo < base_reward);
 
     reward = reward_lo;
+    reward = HAVEN_MAX_TX_VALUE;
     return true;
   }
   //------------------------------------------------------------------------------------

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4753,8 +4753,8 @@ bool Blockchain::check_fee(size_t tx_weight, uint64_t fee, const offshore::prici
   
   if (fee < needed_fee - needed_fee / 50) // keep a little 2% buffer on acceptance - no integer overflow
   {
-    MERROR_VER("transaction fee is not enough: " << print_money(fee) << ", minimum fee: " << print_money(needed_fee));
-    return false;
+    //MERROR_VER("transaction fee is not enough: " << print_money(fee) << ", minimum fee: " << print_money(needed_fee));
+    //return false;
   }
   return true;
 }

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2521,7 +2521,7 @@ bool t_rpc_command_executor::rpc_payments()
     }
 
     const uint64_t now = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    uint64_t balance = 0;
+    boost::multiprecision::uint128_t balance = 0;
     tools::msg_writer() << boost::format("%64s %16u %16u %8u %8u %8u %8u %s")
         % "Client ID" % "Balance" % "Total mined" % "Good" % "Stale" % "Bad" % "Dupes" % "Last update";
     for (const auto &entry: res.entries)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -35,6 +35,7 @@
  */
 
 // use boost bind placeholders for now
+#include <boost/multiprecision/cpp_int.hpp>
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS 1
 #include <boost/bind.hpp>
 
@@ -6304,11 +6305,11 @@ bool simple_wallet::show_balance_unlocked(bool detailed)
   const std::string tag = m_wallet->get_account_tags().second[m_current_subaddress_account];
   success_msg_writer() << tr("Tag: ") << (tag.empty() ? std::string{tr("(No tag assigned)")} : tag);
   for (const auto& asset: offshore::ASSET_TYPES) {
-    uint64_t balance = m_wallet->balance(m_current_subaddress_account, asset, false);
+    boost::multiprecision::uint128_t balance = m_wallet->balance(m_current_subaddress_account, asset, false);
     if (balance == 0)
       continue;
     uint64_t blocks_to_unlock, time_to_unlock;
-    uint64_t unlocked_balance = m_wallet->unlocked_balance(m_current_subaddress_account, asset, false, &blocks_to_unlock, &time_to_unlock);
+    boost::multiprecision::uint128_t unlocked_balance = m_wallet->unlocked_balance(m_current_subaddress_account, asset, false, &blocks_to_unlock, &time_to_unlock);
     std::string unlock_time_message;
     if (blocks_to_unlock > 0 && time_to_unlock > 0)
       unlock_time_message = (boost::format(" (%lu block(s) and %s to unlock)") % blocks_to_unlock % get_human_readable_timespan(time_to_unlock)).str();
@@ -6319,8 +6320,8 @@ bool simple_wallet::show_balance_unlocked(bool detailed)
     success_msg_writer() << tr("Balance: ") << print_money(balance) << ", "
       << tr("unlocked balance: ") << print_money(unlocked_balance) << "  " << asset << " " << unlock_time_message << extra;
   }
-  std::map<uint32_t, uint64_t> balance_per_subaddress = m_wallet->balance_per_subaddress(m_current_subaddress_account, "XHV", false);
-  std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlocked_balance_per_subaddress = m_wallet->unlocked_balance_per_subaddress(m_current_subaddress_account, "XHV", false);
+  std::map<uint32_t, boost::multiprecision::uint128_t> balance_per_subaddress = m_wallet->balance_per_subaddress(m_current_subaddress_account, "XHV", false);
+  std::map<uint32_t, std::pair<boost::multiprecision::uint128_t, std::pair<uint64_t, uint64_t>>> unlocked_balance_per_subaddress = m_wallet->unlocked_balance_per_subaddress(m_current_subaddress_account, "XHV", false);
   if (!detailed || balance_per_subaddress.empty())
     return true;
   success_msg_writer() << tr("Balance per address:");
@@ -10767,7 +10768,7 @@ void simple_wallet::print_accounts(const std::string& tag)
   success_msg_writer() << boost::format("  %15s %21s %21s %21s %21s") % tr("Account") % tr("Balance") % tr("Unlocked balance") % tr("Asset") % tr("Label");
   std::map<std::string, std::pair<uint64_t, uint64_t>> total_balances;
   for (const auto& asset: offshore::ASSET_TYPES) {
-    uint64_t total_balance = 0, total_unlocked_balance = 0;
+    boost::multiprecision::uint128_t total_balance = 0, total_unlocked_balance = 0;
     for (uint32_t account_index = 0; account_index < m_wallet->get_num_subaddress_accounts(); ++account_index)
     {
       if (account_tags.second[account_index] != tag)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1063,20 +1063,20 @@ private:
     hw::device::device_type get_device_type() const { return m_key_device_type; }
     bool reconnect_device();
     // all locked & unlocked balances of all subaddress accounts
-    std::map<std::string, uint64_t> balance_all(bool strict);
-    std::map<std::string, uint64_t> unlocked_balance_all(bool strict, std::map<std::string, uint64_t> *blocks_to_unlock = NULL, std::map<std::string, uint64_t> *time_to_unlock = NULL); 
+    std::map<std::string, boost::multiprecision::uint128_t> balance_all(bool strict);
+    std::map<std::string, boost::multiprecision::uint128_t> unlocked_balance_all(bool strict, std::map<std::string, uint64_t> *blocks_to_unlock = NULL, std::map<std::string, uint64_t> *time_to_unlock = NULL); 
     // locked & unlocked balance of given or current subaddress account
-    uint64_t balance(uint32_t subaddr_index_major, const std::string& asset, bool strict) const;
-    uint64_t unlocked_balance(uint32_t subaddr_index_major, const std::string& asset, bool strict, uint64_t *blocks_to_unlock = NULL, uint64_t *time_to_unlock = NULL);
+    boost::multiprecision::uint128_t balance(uint32_t subaddr_index_major, const std::string& asset, bool strict) const;
+    boost::multiprecision::uint128_t unlocked_balance(uint32_t subaddr_index_major, const std::string& asset, bool strict, uint64_t *blocks_to_unlock = NULL, uint64_t *time_to_unlock = NULL);
     // locked & unlocked balance of given or current subaddress account
-    std::map<uint32_t, std::map<std::string, uint64_t>> balance(uint32_t subaddr_index_major, bool strict);
-    std::map<uint32_t, std::map<std::string, uint64_t>> unlocked_balance(uint32_t subaddr_index_major, bool strict, std::map<std::string, uint64_t> *blocks_to_unlock = NULL, std::map<std::string, uint64_t> *time_to_unlock = NULL);
+    std::map<uint32_t, std::map<std::string, boost::multiprecision::uint128_t>> balance(uint32_t subaddr_index_major, bool strict);
+    std::map<uint32_t, std::map<std::string, boost::multiprecision::uint128_t>> unlocked_balance(uint32_t subaddr_index_major, bool strict, std::map<std::string, uint64_t> *blocks_to_unlock = NULL, std::map<std::string, uint64_t> *time_to_unlock = NULL);
     // locked & unlocked balance per subaddress of given or current subaddress account
-    std::map<uint32_t, uint64_t> balance_per_subaddress(uint32_t subaddr_index_major, const std::string& asset, bool strict) const;
-    std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlocked_balance_per_subaddress(uint32_t subaddr_index_major, const std::string& asset, bool strict);
+    std::map<uint32_t, boost::multiprecision::uint128_t> balance_per_subaddress(uint32_t subaddr_index_major, const std::string& asset, bool strict) const;
+    std::map<uint32_t, std::pair<boost::multiprecision::uint128_t, std::pair<uint64_t, uint64_t>>> unlocked_balance_per_subaddress(uint32_t subaddr_index_major, const std::string& asset, bool strict);
     // all locked & unlocked balances of all subaddress accounts
-    uint64_t balance_all(bool strict, const std::string& asset) const;
-    uint64_t unlocked_balance_all(bool strict, const std::string& asset, uint64_t *blocks_to_unlock = NULL, uint64_t *time_to_unlock = NULL);
+    boost::multiprecision::uint128_t balance_all(bool strict, const std::string& asset) const;
+    boost::multiprecision::uint128_t unlocked_balance_all(bool strict, const std::string& asset, uint64_t *blocks_to_unlock = NULL, uint64_t *time_to_unlock = NULL);
     template<typename T>
     void transfer_selected(const std::vector<cryptonote::tx_destination_entry>& dsts, const std::vector<size_t>& selected_transfers, size_t fake_outputs_count,
       std::vector<std::vector<tools::wallet2::get_outs_entry>> &outs, std::unordered_set<crypto::public_key> &valid_public_keys_cache,
@@ -2005,8 +2005,8 @@ private:
     uint64_t m_light_wallet_blockchain_height;
     uint64_t m_light_wallet_per_kb_fee = FEE_PER_KB;
     bool m_light_wallet_connected;
-    uint64_t m_light_wallet_balance;
-    uint64_t m_light_wallet_unlocked_balance;
+    boost::multiprecision::uint128_t m_light_wallet_balance;
+    boost::multiprecision::uint128_t m_light_wallet_unlocked_balance;
     // Light wallet info needed to populate m_payment requires 2 separate api calls (get_address_txs and get_unspent_outs)
     // We save the info from the first call in m_light_wallet_address_txs for easier lookup.
     std::unordered_map<crypto::hash, address_tx> m_light_wallet_address_txs;

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -35,6 +35,7 @@
 #include "cryptonote_basic/subaddress_index.h"
 #include "crypto/hash.h"
 #include "wallet_rpc_server_error_codes.h"
+#include <boost/multiprecision/cpp_int.hpp>
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "wallet.rpc"
@@ -83,8 +84,8 @@ namespace wallet_rpc
       uint32_t account_index;
       uint32_t address_index;
       std::string address;
-      uint64_t balance;
-      uint64_t unlocked_balance;
+      std::string balance;
+      std::string unlocked_balance;
       std::string label;
       uint64_t num_unspent_outputs;
       uint64_t blocks_to_unlock;
@@ -104,8 +105,8 @@ namespace wallet_rpc
     };
 
     struct balance_info {
-      uint64_t 	 balance;
-      uint64_t 	 unlocked_balance;
+      std::string 	 balance;
+      std::string 	 unlocked_balance;
       bool       multisig_import_needed;
       std::vector<per_subaddress_info> per_subaddress;
       uint64_t   blocks_to_unlock;
@@ -270,8 +271,8 @@ namespace wallet_rpc
     {
       uint32_t account_index;
       std::string base_address;
-      uint64_t balance;
-      uint64_t unlocked_balance;
+      std::string balance;
+      std::string unlocked_balance;
       std::string label;
       std::string tag;
 
@@ -287,8 +288,8 @@ namespace wallet_rpc
 
     struct response_t
     {
-      uint64_t total_balance;
-      uint64_t total_unlocked_balance;
+      std::string total_balance;
+      std::string total_unlocked_balance;
       std::vector<subaddress_account_info> subaddress_accounts;
 
       BEGIN_KV_SERIALIZE_MAP()


### PR DESCRIPTION
DO NOT MERGE TO MASTER OR INCLUDE IN ANY RELEASE.
THIS PR IS MEANT FOR TESTING ONLY
IT DISABLES SOME VALIDATION CHECKS AND ALSO MODIFIES MINING REWARDS

Scope of changes:
- Mining reward set to 15 million, to speed up wallet overflow
- Wallet support for processing of incoming transfers which in total exceed 18 million
- Support for creating transfers from such wallets, which are currently capped at 9 million
- Changes to RPC calls to allow display of balances above 18 million. They are now returned as string.